### PR TITLE
Make the library definition flow file strict

### DIFF
--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,4 +1,6 @@
+/* @flow strict */
+
 declare module.exports: {
   install(container: HTMLElement): void;
   uninstall(container: HTMLElement): void;
-}
+};


### PR DESCRIPTION
**TURNS OUT, I'VE BEEN WRONG ALL ALONG**

I thought (and have been suggesting in reviews 😬) that flow files don't need the strict comment because they are strict by default _BUT_ it appears that I'm very wrong. I'm gonna try to blame this on the lack of documentation of `.js.flow` types but it's pretty much on me, sorry 😭 