### PR TITLE
updated example code in readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ See [the list of `KeyboardEvent` key values](https://developer.mozilla.org/en-US
 
 ```js
 import {install} from '@github/hotkey'
-for (const el of document.querySelector('[data-hotkey]')) {
+for (const el of document.querySelectorAll('[data-hotkey]')) {
   install(el)
 }
 ```


### PR DESCRIPTION
`document.querySelector` returns either a `null` or the first of matching elements. It must be `document.querySelectorAll` to work as intended.