### PR TITLE
Don't mandate the use of the `data-hotkey` attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,18 @@
 # Hotkey Behavior
 
-Trigger a action on element when keyboard hotkey is pressed.
+Trigger an action on a target element when a key or sequence of keys is pressed
+on the keyboard. This triggers a focus event on form elements, or a click event on
+link, button, and summary elements.
 
-Automatically binds hotkeys to any link with a `data-hotkey`
-attribute set. Multiple hotkeys are separated by a `,`.
-Key combinations are separated by a `+`, and key sequences
-are separated by a space.
+By default, hotkeys are extracted from a target element's `data-hotkey`
+attribute, but this can be overridden by passing the hotkey to the registering
+function (`install`) as a parameter.
 
-Two-keypress sequences like `g c` and `g i` would be stored
-under the 'g' key in a nested object with keys 'c' and 'i'.
+Multiple hotkeys are separated by a `,`; key combinations are separated
+by a `+`; and key sequences are separated by a space.
+
+Two-keypress sequences such as `g c` and `g i` are stored
+under the 'g' key in a nested object with 'c' and 'i' keys.
 
 ```
 mappings =
@@ -18,10 +22,10 @@ mappings =
     'i'   : <a href="/rails/rails/issues" data-hotkey="g i">Issues</a>
 ```
 
-So both `g c` and `c` could be available hotkeys on the same
-page, but `g c` and `g` couldn't coexist. If the user presses
-`g`, the `c` hotkey will be unavailable for 1500ms while we
-listen for either `g c` or `g i`.
+In this example, both `g c` and `c` could be available as hotkeys on the
+same page, but `g c` and `g` can't coexist. If the user presses
+`g`, the `c` hotkey will be unavailable for 1500 ms while we
+wait for either `g c` or `g i`.
 
 ## Accessibility considerations
 
@@ -56,8 +60,19 @@ See [the list of `KeyboardEvent` key values](https://developer.mozilla.org/en-US
 
 ```js
 import {install} from '@github/hotkey'
+
 for (const el of document.querySelectorAll('[data-hotkey]')) {
-  install(el)
+  install(el) // or install(el, hotkey)
+}
+```
+
+To unregister a hotkey from an element, use `uninstall`:
+
+```js
+import {uninstall} from '@github/hotkey'
+
+for (const el of document.querySelectorAll('[data-hotkey]')) {
+  uninstall(el)
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Hotkey Behavior
 
 Trigger an action on a target element when a key or sequence of keys is pressed
-on the keyboard. This triggers a focus event on form elements, or a click event on
-link, button, and summary elements.
+on the keyboard. This triggers a focus event on form fields, or a click event on
+`<a href="...">`, `<button>` and `<summary>` elements.
 
 By default, hotkeys are extracted from a target element's `data-hotkey`
 attribute, but this can be overridden by passing the hotkey to the registering
@@ -62,7 +62,15 @@ See [the list of `KeyboardEvent` key values](https://developer.mozilla.org/en-US
 import {install} from '@github/hotkey'
 
 for (const el of document.querySelectorAll('[data-hotkey]')) {
-  install(el) // or install(el, hotkey)
+  install(el)
+}
+```
+
+Alternatively, the hotkey(s) can be passed to the `install` function as a parameter e.g.:
+
+```js
+for (const el of document.querySelectorAll('[data-shortcut]')) {
+  install(el, el.dataset.shortcut)
 }
 ```
 

--- a/src/index.js
+++ b/src/index.js
@@ -41,8 +41,8 @@ document.addEventListener('keydown', (event: KeyboardEvent) => {
 
 export {RadixTrie, Leaf}
 
-export function install(element: HTMLElement) {
-  const hotkeys = expandHotkeyToEdges(element.getAttribute('data-hotkey') || '')
+export function install(element: HTMLElement, hotkey?: string) {
+  const hotkeys = expandHotkeyToEdges(hotkey || element.getAttribute('data-hotkey') || '')
   const leaves = hotkeys.map(hotkey => hotkeyRadixTrie.insert(hotkey).add(element))
   elementsLeaves.set(element, leaves)
 }

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -1,6 +1,6 @@
 /* @flow strict */
 
 declare module.exports: {
-  install(container: Element): void;
+  install(container: Element, hotkey?: string): void;
   uninstall(container: Element): void;
 };

--- a/test/test-radix-trie.js
+++ b/test/test-radix-trie.js
@@ -54,7 +54,7 @@ describe('RadixTrie', () => {
       assert.instanceOf(otherLeaf, Leaf, 'otherLeaf isnt a Leaf instance')
     })
 
-    it('overrides leafs with new deeper insertions', () => {
+    it('overrides leaves with new deeper insertions', () => {
       const trie = new RadixTrie()
       const otherLeaf = trie.insert(['g', 'c', 'e'])
 

--- a/test/test.js
+++ b/test/test.js
@@ -17,7 +17,11 @@ describe('hotkey', function() {
       button.addEventListener('click', buttonClickHandler)
     }
     for (const button of document.querySelectorAll('[data-hotkey]')) {
-      hotkey.install(button)
+      if (button.id === 'button3') {
+        hotkey.install(button, 'Control+c')
+      } else {
+        hotkey.install(button)
+      }
     }
   })
 
@@ -32,14 +36,24 @@ describe('hotkey', function() {
     buttonsClicked = []
   })
 
-  it('triggers buttons that have `data-hotkey` as a attribute', function() {
+  it('triggers buttons that have a `data-hotkey` attribute', function() {
     document.dispatchEvent(new KeyboardEvent('keydown', {key: 'b'}))
     assert.include(buttonsClicked, 'button1')
   })
 
-  it("doesn't trigger buttons that don't have `data-hotkey` as a attribute", function() {
+  it('triggers buttons that have a `data-hotkey` attribute which is overriden by a hotkey parameter', function() {
+    document.dispatchEvent(new KeyboardEvent('keydown', {key: 'c', ctrlKey: true}))
+    assert.include(buttonsClicked, 'button3')
+  })
+
+  it("doesn't trigger buttons that don't have a `data-hotkey` attribute", function() {
     document.dispatchEvent(new KeyboardEvent('keydown', {key: 'b'}))
     assert.notInclude(buttonsClicked, 'button2')
+  })
+
+  it("doesn't respond to the hotkey in a button's overriden `data-hotkey` attribute", function() {
+    document.dispatchEvent(new KeyboardEvent('keydown', {key: 'b', ctrlKey: true}))
+    assert.notInclude(buttonsClicked, 'button3')
   })
 
   it("doesn't trigger when user is focused on a form field", function() {
@@ -48,11 +62,11 @@ describe('hotkey', function() {
   })
 
   it('handles multiple keys in a hotkey combination', function() {
-    document.dispatchEvent(new KeyboardEvent('keydown', {key: 'b', ctrlKey: true}))
+    document.dispatchEvent(new KeyboardEvent('keydown', {key: 'c', ctrlKey: true}))
     assert.include(buttonsClicked, 'button3')
   })
 
-  it("doesn't trigger elements where the hotkey library has been uninstalled", function() {
+  it("doesn't trigger elements whose hotkey has been removed", function() {
     hotkey.uninstall(document.querySelector('#button1'))
     document.dispatchEvent(new KeyboardEvent('keydown', {key: 'b'}))
     assert.deepEqual(buttonsClicked, [])


### PR DESCRIPTION
Allow the hotkey to be passed to the registering function (`install`) as an optional parameter, rather than requiring the use of the `data-hotkey` attribute. And update and expand the documentation (closes #5).