### PR TITLE
Register keydown handler on first install

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,10 +59,7 @@ See [the list of `KeyboardEvent` key values](https://developer.mozilla.org/en-US
 ### JS
 
 ```js
-import {install, keyDownHandler} from '@github/hotkey'
-
-// Register the global key handler
-document.addEventListener('keydown', keyDownHandler)
+import {install} from '@github/hotkey'
 
 // Install all the hotkeys on the page
 for (const el of document.querySelectorAll('[data-hotkey]')) {

--- a/README.md
+++ b/README.md
@@ -59,8 +59,12 @@ See [the list of `KeyboardEvent` key values](https://developer.mozilla.org/en-US
 ### JS
 
 ```js
-import {install} from '@github/hotkey'
+import {install, keyDownHandler} from '@github/hotkey'
 
+// Register the global key handler
+document.addEventListener('keydown', keyDownHandler)
+
+// Install all the hotkeys on the page
 for (const el of document.querySelectorAll('[data-hotkey]')) {
   install(el)
 }

--- a/src/index.js
+++ b/src/index.js
@@ -6,7 +6,6 @@ import eventToHotkeyString from './hotkey'
 
 const hotkeyRadixTrie = new RadixTrie()
 const elementsLeaves = new WeakMap()
-let hotkeysInstalled = 0
 let currentTriePosition = hotkeyRadixTrie
 let resetTriePositionTimer = null
 
@@ -44,10 +43,9 @@ export {RadixTrie, Leaf, eventToHotkeyString}
 
 export function install(element: HTMLElement, hotkey?: string) {
   // Install the keydown handler if this is the first install
-  if (hotkeysInstalled === 0) {
+  if (Object.keys(hotkeyRadixTrie.children).length === 0) {
     document.addEventListener('keydown', keyDownHandler)
   }
-  hotkeysInstalled = hotkeysInstalled + 1
 
   const hotkeys = expandHotkeyToEdges(hotkey || element.getAttribute('data-hotkey') || '')
   const leaves = hotkeys.map(hotkey => hotkeyRadixTrie.insert(hotkey).add(element))
@@ -62,8 +60,7 @@ export function uninstall(element: HTMLElement) {
     }
   }
 
-  hotkeysInstalled = hotkeysInstalled - 1
-  if (hotkeysInstalled === 0) {
+  if (Object.keys(hotkeyRadixTrie.children).length === 0) {
     document.removeEventListener('keydown', keyDownHandler)
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ function resetTriePosition() {
   currentTriePosition = hotkeyRadixTrie
 }
 
-document.addEventListener('keydown', (event: KeyboardEvent) => {
+export function keyDownHandler(event: KeyboardEvent) {
   if (event.target instanceof Node && isFormField(event.target)) return
 
   if (resetTriePositionTimer != null) {
@@ -37,7 +37,7 @@ document.addEventListener('keydown', (event: KeyboardEvent) => {
     resetTriePosition()
     return
   }
-})
+}
 
 export {RadixTrie, Leaf, eventToHotkeyString}
 

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -4,5 +4,4 @@ declare module.exports: {
   install(container: Element, hotkey?: string): void;
   uninstall(container: Element): void;
   eventToHotkeyString(event: Event): string;
-  keyDownHandler(event: KeyboardEvent): void;
 };

--- a/src/index.js.flow
+++ b/src/index.js.flow
@@ -4,4 +4,5 @@ declare module.exports: {
   install(container: Element, hotkey?: string): void;
   uninstall(container: Element): void;
   eventToHotkeyString(event: Event): string;
+  keyDownHandler(event: KeyboardEvent): void;
 };

--- a/test/test.js
+++ b/test/test.js
@@ -40,6 +40,7 @@ describe('hotkey', function() {
     for (const element of document.querySelectorAll('[data-hotkey]')) {
       hotkey.uninstall(element)
     }
+    hotkey.uninstall(document.getElementById('button-without-a-attribute'))
     document.body.innerHTML = ''
     elementsActivated = []
   })
@@ -51,11 +52,11 @@ describe('hotkey', function() {
       assert.include(elementsActivated, 'button1')
     })
 
-    it('triggers buttons that have a `data-hotkey` attribute which is overriden by a hotkey parameter', function() {
-      setHTML('<button id="button3" data-hotkey="Control+b">Button 3</button>')
-      hotkey.install(document.getElementById('button3'), 'Control+c')
+    it('triggers buttons that get hotkey passed in as second argument', function() {
+      setHTML('<button id="button-without-a-attribute">Button 3</button>')
+      hotkey.install(document.getElementById('button-without-a-attribute'), 'Control+c')
       document.dispatchEvent(new KeyboardEvent('keydown', {key: 'c', ctrlKey: true}))
-      assert.include(elementsActivated, 'button3')
+      assert.include(elementsActivated, 'button-without-a-attribute')
     })
 
     it("doesn't trigger buttons that don't have a `data-hotkey` attribute", function() {

--- a/test/test.js
+++ b/test/test.js
@@ -8,6 +8,8 @@ function clickHandler(event) {
 const setHTML = html => {
   document.body.innerHTML = html
 
+  document.addEventListener('keydown', hotkey.keyDownHandler)
+
   for (const element of document.querySelectorAll('[data-hotkey]')) {
     hotkey.install(element)
   }


### PR DESCRIPTION
Rather then registering a global keyhandler for the consumers of `github/hotkey`, this PR exposes the keydown handler and puts the onus of registering it on the consumer.

cc/ @muan 