### PR TITLE
Support of checkbox and radio input elements

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -10,15 +10,30 @@ export function isFormField(element: Node): boolean {
   return (
     name === 'select' ||
     name === 'textarea' ||
-    (name === 'input' && type !== 'submit' && type !== 'reset') ||
+    (name === 'input' && type !== 'submit' && type !== 'reset' && type !== 'checkbox') ||
     element.isContentEditable
   )
+}
+
+function isActivableFormField(element: Node): boolean {
+  if (!(element instanceof HTMLElement)) {
+    return false
+  }
+
+  const name = element.nodeName.toLowerCase()
+  const type = (element.getAttribute('type') || '').toLowerCase()
+  return name === 'input' && type === 'checkbox'
 }
 
 export function fireDeterminedAction(el: HTMLElement): void {
   if (isFormField(el)) {
     el.focus()
-  } else if ((el instanceof HTMLAnchorElement && el.href) || el.tagName === 'BUTTON' || el.tagName === 'SUMMARY') {
+  } else if (
+    (el instanceof HTMLAnchorElement && el.href) ||
+    el.tagName === 'BUTTON' ||
+    el.tagName === 'SUMMARY' ||
+    isActivableFormField(el)
+  ) {
     el.click()
   }
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -10,7 +10,7 @@ export function isFormField(element: Node): boolean {
   return (
     name === 'select' ||
     name === 'textarea' ||
-    (name === 'input' && type !== 'submit' && type !== 'reset' && type !== 'checkbox') ||
+    (name === 'input' && type !== 'submit' && type !== 'reset' && type !== 'checkbox' && type !== 'radio') ||
     element.isContentEditable
   )
 }
@@ -22,7 +22,7 @@ function isActivableFormField(element: Node): boolean {
 
   const name = element.nodeName.toLowerCase()
   const type = (element.getAttribute('type') || '').toLowerCase()
-  return name === 'input' && type === 'checkbox'
+  return name === 'input' && (type === 'checkbox' || type === 'radio')
 }
 
 export function fireDeterminedAction(el: HTMLElement): void {

--- a/test/test.js
+++ b/test/test.js
@@ -186,6 +186,14 @@ describe('hotkey', function() {
       assert.deepEqual(elementsActivated, [])
     })
 
+    it('will activate checkbox input elements that have a hotkey attribute', async () => {
+      setHTML('<input type="checkbox" id="checkbox" data-hotkey="a">')
+
+      document.dispatchEvent(new KeyboardEvent('keydown', {key: 'a'}))
+
+      assert.deepEqual(elementsActivated, ['checkbox'])
+    })
+
     it('can click a[href] elements that declare data-hotkey for activation', async () => {
       setHTML('<a id="link" href="#" data-hotkey="a b">')
 

--- a/test/test.js
+++ b/test/test.js
@@ -194,6 +194,14 @@ describe('hotkey', function() {
       assert.deepEqual(elementsActivated, ['checkbox'])
     })
 
+    it('will activate radio button input elements that have a hotkey attribute', async () => {
+      setHTML('<input type="radio" id="radio" data-hotkey="a">')
+
+      document.dispatchEvent(new KeyboardEvent('keydown', {key: 'a'}))
+
+      assert.deepEqual(elementsActivated, ['radio'])
+    })
+
     it('can click a[href] elements that declare data-hotkey for activation', async () => {
       setHTML('<a id="link" href="#" data-hotkey="a b">')
 


### PR DESCRIPTION
Instead of focusing radio and checkbox input elements we should simulate click them like how we do with buttons and links.