### PR TITLE
added support for triggering click events on any element with role="b…

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Trigger an action on a target element when a key or sequence of keys is pressed
 on the keyboard. This triggers a focus event on form fields, or a click event on
-`<a href="...">`, `<button>` and `<summary>` elements.
+`<a href="...">`, `<button>`, `<summary>` or `<div role="button">` (any element with `role="button"` attribute) elements.
 
 By default, hotkeys are extracted from a target element's `data-hotkey`
 attribute, but this can be overridden by passing the hotkey to the registering

--- a/src/utils.js
+++ b/src/utils.js
@@ -25,6 +25,14 @@ function isActivableFormField(element: Node): boolean {
   return name === 'input' && (type === 'checkbox' || type === 'radio')
 }
 
+function isButtonLikeElement(element: Node): boolean {
+  if (!(element instanceof HTMLElement)) {
+    return false
+  }
+
+  return element.getAttribute('role') === 'button'
+}
+
 export function fireDeterminedAction(el: HTMLElement): void {
   if (isFormField(el)) {
     el.focus()
@@ -32,7 +40,8 @@ export function fireDeterminedAction(el: HTMLElement): void {
     (el instanceof HTMLAnchorElement && el.href) ||
     el.tagName === 'BUTTON' ||
     el.tagName === 'SUMMARY' ||
-    isActivableFormField(el)
+    isActivableFormField(el) ||
+    isButtonLikeElement(el)
   ) {
     el.click()
   }

--- a/test/test.js
+++ b/test/test.js
@@ -228,6 +228,15 @@ describe('hotkey', function() {
 
       assert.deepEqual(elementsActivated, ['summary'])
     })
+
+    it('can click any element with role == button attribute that declare data-hotkey for activation', async () => {
+      setHTML('<div id="my-pseudo-btn" role="button" data-hotkey="p d" />')
+
+      document.dispatchEvent(new KeyboardEvent('keydown', {key: 'p'}))
+      document.dispatchEvent(new KeyboardEvent('keydown', {key: 'd'}))
+
+      assert.deepEqual(elementsActivated, ['my-pseudo-btn'])
+    })
   })
 })
 


### PR DESCRIPTION
`<div role="button" ...>` is a common way of marking elements's purpose as button for reasons of accessibility (see [this discussion](https://stackoverflow.com/a/18664038))

It's commonly used ([see vim-vixen](https://github.com/ueokande/vim-vixen/blob/07897df636ca3e732490d53fd2acf947738bf16e/src/content/presenters/FollowPresenter.ts#L7))

And we see some frameworks, that use div for their clickable elements (like [material-ui](https://github.com/mui-org/material-ui/blob/83f5e19df32a124d65b38c521e78844c7030e6d2/packages/material-ui/src/Select/SelectInput.js#L283))
