### PR TITLE
fix: enable support for meta+shift plane

### DIFF
--- a/src/hotkey.js
+++ b/src/hotkey.js
@@ -27,5 +27,7 @@
 //
 // Returns key character String or null.
 export default function hotkey(event: KeyboardEvent) {
-  return `${event.ctrlKey ? 'Control+' : ''}${event.altKey ? 'Alt+' : ''}${event.metaKey ? 'Meta+' : ''}${event.key}`
+  return `${event.ctrlKey ? 'Control+' : ''}${event.altKey ? 'Alt+' : ''}${event.metaKey ? 'Meta+' : ''}${
+    event.shiftKey ? 'Shift+' : ''
+  }${event.key}`
 }

--- a/test/test.js
+++ b/test/test.js
@@ -169,6 +169,16 @@ describe('hotkey', function() {
       await keySequence('c')
       assert.deepEqual(elementsActivated, ['duplicate2'])
     })
+
+    it('works with macos meta+shift plane', async () => {
+      setHTML(`<a href="#" id="metashiftplane" data-hotkey="Meta+Shift+p"></a>`)
+
+      document.dispatchEvent(new KeyboardEvent('keydown', {metaKey: true, shiftKey: true, key: 'p'}))
+
+      await wait(10)
+
+      assert.deepEqual(elementsActivated, ['metashiftplane'])
+    })
   })
 
   describe('elements', function() {


### PR DESCRIPTION
This library currently does not have support for interacting with the `shift` plane of keyboard shortcuts. You can interact with them _coincidentally_ by using a capital letter key, e.g. `Control+P` is the equivalent of `Control+Shift+P`. The problem is that on macos the `Meta+Shift+` plane is always lowercase, and as such is inaccessible using this library.

This fixes the issue by adding `shiftKey` as `Shift+` in the `hotkey` function.