### PR TITLE
fix: support for meta+shift plane while retaining short upper chars

### DIFF
--- a/src/hotkey.js
+++ b/src/hotkey.js
@@ -28,6 +28,6 @@
 // Returns key character String or null.
 export default function hotkey(event: KeyboardEvent) {
   return `${event.ctrlKey ? 'Control+' : ''}${event.altKey ? 'Alt+' : ''}${event.metaKey ? 'Meta+' : ''}${
-    event.shiftKey ? 'Shift+' : ''
+    event.shiftKey && event.key.toUpperCase() !== event.key ? 'Shift+' : ''
   }${event.key}`
 }

--- a/test/test.js
+++ b/test/test.js
@@ -90,6 +90,12 @@ describe('hotkey', function() {
       document.dispatchEvent(new KeyboardEvent('keydown', {key: 'b'}))
       assert.deepEqual(elementsActivated, [])
     })
+
+    it('triggers elements with capitalised key', function() {
+      setHTML('<button id="button1" data-hotkey="B">Button 1</button>')
+      document.dispatchEvent(new KeyboardEvent('keydown', {shiftKey: true, key: 'B'}))
+      assert.include(elementsActivated, 'button1')
+    })
   })
 
   describe('eventToHotkeyString', function() {


### PR DESCRIPTION
I raised https://github.com/github/hotkey/pull/25 in the hopes of adding support for the `meta+shift` plane, but this broke shortcuts like `data-key=B` because it is expecting `data-key=Shift+B`. The tests were passing because our tests have capitals without `shiftKey = true`.

This fixes the breakage in 1.3.1 by adding a check to _only_ add the `Shift+` modifier if `event.key.toUpperCase() !== event.key`, allowing for both `data-key="Meta+Shift+b"`/`data-key="B"`