### PR TITLE
Remove syntax transformations in module output

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,11 +3,11 @@
   "version": "1.3.2",
   "description": "",
   "main": "dist/index.umd.js",
-  "module": "dist/index.esm.js",
+  "module": "dist/index.js",
   "types": "index.d.ts",
   "repository": "github/hotkey",
   "scripts": {
-    "build": "rollup -c && cp src/index.js.flow dist/index.esm.js.flow && cp src/index.js.flow dist/index.umd.js.flow",
+    "build": "rollup -c && cp src/index.js.flow dist/index.js.flow && cp src/index.js.flow dist/index.umd.js.flow",
     "lint": "github-lint",
     "test": "karma start test/karma.config.js",
     "clean": "rm -rf dist",
@@ -21,7 +21,6 @@
     "index.d.ts"
   ],
   "keywords": [],
-  "author": "",
   "license": "MIT",
   "prettier": "@github/prettier-config",
   "devDependencies": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -4,23 +4,25 @@ import babel from 'rollup-plugin-babel'
 
 const pkg = require('./package.json')
 
-export default {
-  input: 'src/index.js',
-  output: [
-    {
-      file: pkg['module'],
-      format: 'es'
-    },
-    {
-      file: pkg['main'],
-      format: 'umd',
-      name: 'hotkey'
-    }
-  ],
-  plugins: [
-    babel({
-      plugins: ['@babel/plugin-proposal-class-properties'],
-      presets: ['@babel/preset-env', '@babel/preset-flow']
-    })
-  ]
-}
+export default [
+  {
+    input: 'src/index.js',
+    output: [{file: pkg['module'], format: 'es'}],
+    plugins: [
+      babel({
+        plugins: ['@babel/plugin-proposal-class-properties'],
+        presets: ['@babel/preset-flow']
+      })
+    ]
+  },
+  {
+    input: 'src/index.js',
+    output: [{file: pkg['main'], format: 'umd', name: 'hotkey'}],
+    plugins: [
+      babel({
+        plugins: ['@babel/plugin-proposal-class-properties'],
+        presets: ['@babel/preset-env', '@babel/preset-flow']
+      })
+    ]
+  }
+]


### PR DESCRIPTION
We're inadvertently transforming the `class` and `for…of` syntax in the module output file. Browsers that support modules also support this syntax, so just strip Flow types during compilation.