### PR TITLE
Check defaultPrevented before triggering hotkey

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ function resetTriePosition() {
 }
 
 function keyDownHandler(event: KeyboardEvent) {
+  if (event.defaultPrevented) return
   if (event.target instanceof Node && isFormField(event.target)) return
 
   if (resetTriePositionTimer != null) {


### PR DESCRIPTION
Ref: https://github.com/github/github/issues/147670

`preventDefault` would need to be called before the event bubbles up to document.

cc @t-hugs @lerebear