### PR TITLE
Feat add data hotkey for

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,20 @@ $ npm install @github/hotkey
 
 See [the list of `KeyboardEvent` key values](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key/Key_Values) for a list of supported key values.
 
+#### Usage within form elements
+
+If the user is currently within a typeable element (an input or textarea) then hotkeys will not fire. This behavior is intentional as these typeable elements will receive a lot of input which may accidentally trigger keyboard shortcuts. In other words - global hotkeys by design will not fire in areas where the user is likely to type.
+
+It is possible to override this behavior by adding `data-hotkey-for` which points to an ID of a form element. A element with `data-hotkey-for` specifically scopes the hotkey activation only to the element which it points to. In other words - these aren't global hotkeys, but are specifically scopes to an element's focus. This allows you to still have shortcut behaviors for an element, but using an opt-in pattern.
+
+
+```html
+<button data-hotkey="j">This will fire when input is not focussed</button>
+
+<button data-hotkey="j" data-hotkey-for="my_id">This will fire when only if input is focussed</button>
+<input id="my_id">
+```
+
 ### JS
 
 ```js

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,6 @@ function resetTriePosition() {
 
 function keyDownHandler(event: KeyboardEvent) {
   if (event.defaultPrevented) return
-  if (event.target instanceof Node && isFormField(event.target)) return
 
   if (resetTriePositionTimer != null) {
     window.clearTimeout(resetTriePositionTimer)
@@ -29,9 +28,26 @@ function keyDownHandler(event: KeyboardEvent) {
     return
   }
 
+  const oldTriePosition = currentTriePosition
   currentTriePosition = newTriePosition
+
   if (newTriePosition instanceof Leaf) {
-    fireDeterminedAction(newTriePosition.children[newTriePosition.children.length - 1])
+    const children = newTriePosition.children
+    const target: Element | null = event.target instanceof Element ? event.target : null
+    const leafElement = children.find((element, i) => {
+      if (target && element.getAttribute('data-hotkey-for') === target.id) return true
+      const isLastElement = children.length - 1 === i
+      return isLastElement
+    })!
+    const forSelector = leafElement.getAttribute('data-hotkey-for')
+    if (target) {
+      if ((!forSelector && isFormField(target)) || forSelector !== target.id) {
+        // Retract the currentTriePosition
+        currentTriePosition = oldTriePosition
+        return
+      }
+    }
+    fireDeterminedAction(leafElement)
     event.preventDefault()
     resetTriePosition()
     return

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,9 @@ import {Leaf, RadixTrie} from './radix-trie'
 import {fireDeterminedAction, expandHotkeyToEdges, isFormField} from './utils'
 import eventToHotkeyString from './hotkey'
 
-const hotkeyRadixTrie = new RadixTrie()
+const hotkeyRadixTrie = new RadixTrie<HTMLElement>()
 const elementsLeaves = new WeakMap<HTMLElement, Array<Leaf<HTMLElement>>>()
-let currentTriePosition: RadixTrie | Leaf<unknown> = hotkeyRadixTrie
+let currentTriePosition: RadixTrie<HTMLElement> | Leaf<HTMLElement> = hotkeyRadixTrie
 let resetTriePositionTimer: number | null = null
 
 function resetTriePosition() {
@@ -23,7 +23,7 @@ function keyDownHandler(event: KeyboardEvent) {
 
   // If the user presses a hotkey that doesn't exist in the Trie,
   // they've pressed a wrong key-combo and we should reset the flow
-  const newTriePosition = (currentTriePosition as RadixTrie).get(eventToHotkeyString(event))
+  const newTriePosition = (currentTriePosition as RadixTrie<HTMLElement>).get(eventToHotkeyString(event))
   if (!newTriePosition) {
     resetTriePosition()
     return
@@ -31,7 +31,7 @@ function keyDownHandler(event: KeyboardEvent) {
 
   currentTriePosition = newTriePosition
   if (newTriePosition instanceof Leaf) {
-    fireDeterminedAction(newTriePosition.children[newTriePosition.children.length - 1] as HTMLElement)
+    fireDeterminedAction(newTriePosition.children[newTriePosition.children.length - 1])
     event.preventDefault()
     resetTriePosition()
     return

--- a/src/radix-trie.ts
+++ b/src/radix-trie.ts
@@ -1,8 +1,8 @@
 export class Leaf<T> {
-  parent: RadixTrie
+  parent: RadixTrie<T>
   children: T[] = []
 
-  constructor(trie: RadixTrie) {
+  constructor(trie: RadixTrie<T>) {
     this.parent = trie
   }
 
@@ -22,24 +22,24 @@ export class Leaf<T> {
   }
 }
 
-export class RadixTrie {
-  parent: RadixTrie | null = null
-  children: {[key: string]: RadixTrie | Leaf<unknown>} = {}
+export class RadixTrie<T> {
+  parent: RadixTrie<T> | null = null
+  children: {[key: string]: RadixTrie<T> | Leaf<T>} = {}
 
-  constructor(trie?: RadixTrie) {
+  constructor(trie?: RadixTrie<T>) {
     this.parent = trie || null
   }
 
-  get(edge: string): RadixTrie | Leaf<unknown> {
+  get(edge: string): RadixTrie<T> | Leaf<T> {
     return this.children[edge]
   }
 
-  insert(edges: string[]): RadixTrie | Leaf<unknown> {
+  insert(edges: string[]): RadixTrie<T> | Leaf<T> {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
-    let currentNode: RadixTrie | Leaf<unknown> = this
+    let currentNode: RadixTrie<T> | Leaf<T> = this
     for (let i = 0; i < edges.length; i += 1) {
       const edge = edges[i]
-      let nextNode: RadixTrie | Leaf<unknown> | null = currentNode.get(edge)
+      let nextNode: RadixTrie<T> | Leaf<T> | null = currentNode.get(edge)
       // If we're at the end of this set of edges:
       if (i === edges.length - 1) {
         // If this end already exists as a RadixTrie, then hose it and replace with a Leaf:
@@ -67,7 +67,7 @@ export class RadixTrie {
     return currentNode
   }
 
-  delete(node: RadixTrie | Leaf<unknown>): boolean {
+  delete(node: RadixTrie<T> | Leaf<T>): boolean {
     for (const edge in this.children) {
       const currentNode = this.children[edge]
       if (currentNode === node) {

--- a/test/test.js
+++ b/test/test.js
@@ -72,7 +72,7 @@ describe('hotkey', function () {
       setHTML(`
       <button id="button1" data-hotkey="b">Button 1</button>
       <input id="textfield" />`)
-      document.getElementById('textfield').dispatchEvent(new KeyboardEvent('keydown', {key: 'b'}))
+      document.getElementById('textfield').dispatchEvent(new KeyboardEvent('keydown', {key: 'b', bubbles: true}))
       assert.deepEqual(elementsActivated, [])
     })
 

--- a/test/test.js
+++ b/test/test.js
@@ -76,6 +76,35 @@ describe('hotkey', function () {
       assert.deepEqual(elementsActivated, [])
     })
 
+    it('triggers when `data-hotkey-for` matches target', function () {
+      setHTML(`
+      <button id="button1" data-hotkey="b" data-hotkey-for="textfield">Button 1</button>
+      <input id="textfield" />`)
+      document.getElementById('textfield').dispatchEvent(new KeyboardEvent('keydown', {key: 'b', bubbles: true}))
+      assert.deepEqual(elementsActivated, ['button1'])
+    })
+
+    it('triggers specifically the `data-hotkey-for` element related to target', function () {
+      setHTML(`
+      <button id="button2" data-hotkey="b" data-hotkey-for="textfield">Button 1</button>
+      <button id="button1" data-hotkey="b">Button 1</button>
+      <input id="textfield" />`)
+      document.getElementById('textfield').dispatchEvent(new KeyboardEvent('keydown', {key: 'b', bubbles: true}))
+      assert.deepEqual(elementsActivated, ['button2'])
+    })
+
+    it("doesn't trigger when `data-hotkey-for` does not match target", function () {
+      setHTML('<button id="button1" data-hotkey="b" data-hotkey-for="other">Button 1</button><div id="element"></div>')
+      document.getElementById('element').dispatchEvent(new KeyboardEvent('keydown', {key: 'b', bubbles: true}))
+      assert.deepEqual(elementsActivated, [])
+    })
+
+    it("doesn't trigger when `data-hotkey-for` does not match form target", function () {
+      setHTML('<button id="button1" data-hotkey="b" data-hotkey-for="other">Button 1</button><input id="element"/>')
+      document.getElementById('element').dispatchEvent(new KeyboardEvent('keydown', {key: 'b', bubbles: true}))
+      assert.deepEqual(elementsActivated, [])
+    })
+
     it('handles multiple keys in a hotkey combination', function () {
       setHTML('<button id="button3" data-hotkey="Control+c">Button 3</button>')
       document.dispatchEvent(new KeyboardEvent('keydown', {key: 'c', ctrlKey: true}))


### PR DESCRIPTION
This is useful for _explictly_ binding hotkeys to a form field, overriding the check that stops key combos firing for form fields.

This provides a way to delegate shortcuts for elements that control the content of a form field (for example toolbar buttons).
