### PR TITLE
Fix for bug where we can't use symbols

### DIFF
--- a/src/hotkey.ts
+++ b/src/hotkey.ts
@@ -26,6 +26,6 @@
 // Returns key character String or null.
 export default function hotkey(event: KeyboardEvent): string {
   return `${event.ctrlKey ? 'Control+' : ''}${event.altKey ? 'Alt+' : ''}${event.metaKey ? 'Meta+' : ''}${
-    event.shiftKey && event.key.toUpperCase() !== event.key ? 'Shift+' : ''
+    event.shiftKey && !event.code.startsWith('Key') ? 'Shift+' : ''
   }${event.key}`
 }

--- a/test/test.js
+++ b/test/test.js
@@ -114,6 +114,15 @@ describe('hotkey', function () {
       })
       document.body.dispatchEvent(new KeyboardEvent('keydown', {key: '1'}))
     })
+    
+    it('keydown with symbol', function (done) {
+      document.body.addEventListener('keydown', function handler(event) {
+        assert.equal(eventToHotkeyString(event), 'Control+Shift+`')
+        document.body.removeEventListener('keydown', handler)
+        done()
+      })
+      document.body.dispatchEvent(new KeyboardEvent('keydown', {ctrlKey: true, shiftKey: true, '`'}))
+    })
   })
 
   describe('hotkey sequence support', function () {

--- a/test/test.js
+++ b/test/test.js
@@ -105,7 +105,34 @@ describe('hotkey', function () {
       })
       document.body.dispatchEvent(new KeyboardEvent('keydown', {key: 'J'}))
     })
-
+    
+    it('keydown with shift and lowercase letter', function (done) {
+      document.body.addEventListener('keydown', function handler(event) {
+        assert.equal(eventToHotkeyString(event), 'Control+Shift+J')
+        document.body.removeEventListener('keydown', handler)
+        done()
+      })
+      document.body.dispatchEvent(new KeyboardEvent('keydown', {ctrlKey: true, shiftKey: true, key: 'j'}))
+    })
+        
+    it('keydown with shift and uppercase letter', function (done) {
+      document.body.addEventListener('keydown', function handler(event) {
+        assert.equal(eventToHotkeyString(event), 'Control+Shift+J')
+        document.body.removeEventListener('keydown', handler)
+        done()
+      })
+      document.body.dispatchEvent(new KeyboardEvent('keydown', {ctrlKey: true, shiftKey: true, key: 'J'}))
+    })
+            
+    it('keydown with lowercase letter', function (done) {
+      document.body.addEventListener('keydown', function handler(event) {
+        assert.equal(eventToHotkeyString(event), 'Control+j')
+        document.body.removeEventListener('keydown', handler)
+        done()
+      })
+      document.body.dispatchEvent(new KeyboardEvent('keydown', {ctrlKey: true, key: 'j'}))
+    })
+    
     it('keydown with number', function (done) {
       document.body.addEventListener('keydown', function handler(event) {
         assert.equal(eventToHotkeyString(event), '1')


### PR DESCRIPTION
There's a bug when trying to use a symbol like <code>Control+Shift+&#96;</code> as the hotkey. See https://github.com/github/github/pull/175242#discussion_r603640676

Because of this line, &#96; doesn't have an uppercase value. 

I'm trying to fix by checking the `KeyboardEvent.code` https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/code value for "Key" which should be alpha numeric.