### PR TITLE
style: give RadixTrie a T

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,9 +2,9 @@ import {Leaf, RadixTrie} from './radix-trie'
 import {fireDeterminedAction, expandHotkeyToEdges, isFormField} from './utils'
 import eventToHotkeyString from './hotkey'
 
-const hotkeyRadixTrie = new RadixTrie()
+const hotkeyRadixTrie = new RadixTrie<HTMLElement>()
 const elementsLeaves = new WeakMap<HTMLElement, Array<Leaf<HTMLElement>>>()
-let currentTriePosition: RadixTrie | Leaf<unknown> = hotkeyRadixTrie
+let currentTriePosition: RadixTrie<HTMLElement> | Leaf<HTMLElement> = hotkeyRadixTrie
 let resetTriePositionTimer: number | null = null
 
 function resetTriePosition() {
@@ -23,7 +23,7 @@ function keyDownHandler(event: KeyboardEvent) {
 
   // If the user presses a hotkey that doesn't exist in the Trie,
   // they've pressed a wrong key-combo and we should reset the flow
-  const newTriePosition = (currentTriePosition as RadixTrie).get(eventToHotkeyString(event))
+  const newTriePosition = (currentTriePosition as RadixTrie<HTMLElement>).get(eventToHotkeyString(event))
   if (!newTriePosition) {
     resetTriePosition()
     return
@@ -31,7 +31,7 @@ function keyDownHandler(event: KeyboardEvent) {
 
   currentTriePosition = newTriePosition
   if (newTriePosition instanceof Leaf) {
-    fireDeterminedAction(newTriePosition.children[newTriePosition.children.length - 1] as HTMLElement)
+    fireDeterminedAction(newTriePosition.children[newTriePosition.children.length - 1])
     event.preventDefault()
     resetTriePosition()
     return

--- a/src/radix-trie.ts
+++ b/src/radix-trie.ts
@@ -1,8 +1,8 @@
 export class Leaf<T> {
-  parent: RadixTrie
+  parent: RadixTrie<T>
   children: T[] = []
 
-  constructor(trie: RadixTrie) {
+  constructor(trie: RadixTrie<T>) {
     this.parent = trie
   }
 
@@ -22,24 +22,24 @@ export class Leaf<T> {
   }
 }
 
-export class RadixTrie {
-  parent: RadixTrie | null = null
-  children: {[key: string]: RadixTrie | Leaf<unknown>} = {}
+export class RadixTrie<T> {
+  parent: RadixTrie<T> | null = null
+  children: {[key: string]: RadixTrie<T> | Leaf<T>} = {}
 
-  constructor(trie?: RadixTrie) {
+  constructor(trie?: RadixTrie<T>) {
     this.parent = trie || null
   }
 
-  get(edge: string): RadixTrie | Leaf<unknown> {
+  get(edge: string): RadixTrie<T> | Leaf<T> {
     return this.children[edge]
   }
 
-  insert(edges: string[]): RadixTrie | Leaf<unknown> {
+  insert(edges: string[]): RadixTrie<T> | Leaf<T> {
     // eslint-disable-next-line @typescript-eslint/no-this-alias
-    let currentNode: RadixTrie | Leaf<unknown> = this
+    let currentNode: RadixTrie<T> | Leaf<T> = this
     for (let i = 0; i < edges.length; i += 1) {
       const edge = edges[i]
-      let nextNode: RadixTrie | Leaf<unknown> | null = currentNode.get(edge)
+      let nextNode: RadixTrie<T> | Leaf<T> | null = currentNode.get(edge)
       // If we're at the end of this set of edges:
       if (i === edges.length - 1) {
         // If this end already exists as a RadixTrie, then hose it and replace with a Leaf:
@@ -67,7 +67,7 @@ export class RadixTrie {
     return currentNode
   }
 
-  delete(node: RadixTrie | Leaf<unknown>): boolean {
+  delete(node: RadixTrie<T> | Leaf<T>): boolean {
     for (const edge in this.children) {
       const currentNode = this.children[edge]
       if (currentNode === node) {


### PR DESCRIPTION
As part of https://github.com/github/hotkey/pull/39 we refactored the `RadixTrie` class to be a `RadixTrie<T>` which makes it much easier to reason about the Leaf node properties.

This is that refactoring as a standlone PR, making https://github.com/github/hotkey/pull/39 smaller.