### PR TITLE
fix: respect key case, elide shift only when case matches

### DIFF
--- a/src/hotkey.ts
+++ b/src/hotkey.ts
@@ -25,8 +25,8 @@
 //
 // Returns key character String or null.
 export default function hotkey(event: KeyboardEvent): string {
-  const elideShift = event.code.startsWith('Key') && event.shiftKey
+  const elideShift = event.code.startsWith('Key') && event.shiftKey && event.key.toUpperCase() === event.key
   return `${event.ctrlKey ? 'Control+' : ''}${event.altKey ? 'Alt+' : ''}${event.metaKey ? 'Meta+' : ''}${
     event.shiftKey && !elideShift ? 'Shift+' : ''
-  }${elideShift ? event.key.toUpperCase() : event.key}`
+  }${event.key}`
 }

--- a/test/test.js
+++ b/test/test.js
@@ -97,59 +97,29 @@ describe('hotkey', function () {
   })
 
   describe('eventToHotkeyString', function () {
-    it('keydown with uppercase letter', function (done) {
-      document.body.addEventListener('keydown', function handler(event) {
-        assert.equal(eventToHotkeyString(event), 'J')
-        document.body.removeEventListener('keydown', handler)
-        done()
+    const tests = [
+      ['Control+J', {ctrlKey: true, shiftKey: true, code: 'KeyJ', key: 'J'}],
+      ['Control+Shift+j', {ctrlKey: true, shiftKey: true, code: 'KeyJ', key: 'j'}],
+      ['Control+j', {ctrlKey: true, code: 'KeyJ', key: 'j'}],
+      ['Meta+Shift+p', {key: 'p', metaKey: true, shiftKey: true, code: 'KeyP'}],
+      ['J', {shiftKey: true, code: 'KeyJ', key: 'J'}],
+      ['/', {key: '/', code: ''}],
+      ['1', {key: '1', code: 'Digit1'}],
+      ['Control+Shift+`', {ctrlKey: true, shiftKey: true, key: '`'}],
+      ['c', {key: 'c', code: 'KeyC'}],
+      ['S', {key: 'S', shiftKey: true, code: 'KeyS'}],
+      ['!', {key: '!', shiftKey: true, code: 'KeyS'}]
+    ]
+    for (const [expected, keyEvent] of tests) {
+      it(`${JSON.stringify(keyEvent)} => ${expected}`, function (done) {
+        document.body.addEventListener('keydown', function handler(event) {
+          document.body.removeEventListener('keydown', handler)
+          assert.equal(eventToHotkeyString(event), expected)
+          done()
+        })
+        document.body.dispatchEvent(new KeyboardEvent('keydown', keyEvent))
       })
-      document.body.dispatchEvent(new KeyboardEvent('keydown', {shiftKey: true, code: 'KeyJ', key: 'J'}))
-    })
-
-    it('keydown with shift and lowercase letter', function (done) {
-      document.body.addEventListener('keydown', function handler(event) {
-        assert.equal(eventToHotkeyString(event), 'Control+J')
-        document.body.removeEventListener('keydown', handler)
-        done()
-      })
-      document.body.dispatchEvent(new KeyboardEvent('keydown', {ctrlKey: true, shiftKey: true, code: 'KeyJ', key: 'j'}))
-    })
-
-    it('keydown with shift and uppercase letter', function (done) {
-      document.body.addEventListener('keydown', function handler(event) {
-        assert.equal(eventToHotkeyString(event), 'Control+J')
-        document.body.removeEventListener('keydown', handler)
-        done()
-      })
-      document.body.dispatchEvent(new KeyboardEvent('keydown', {ctrlKey: true, shiftKey: true, code: 'KeyJ', key: 'J'}))
-    })
-
-    it('keydown with lowercase letter', function (done) {
-      document.body.addEventListener('keydown', function handler(event) {
-        assert.equal(eventToHotkeyString(event), 'Control+j')
-        document.body.removeEventListener('keydown', handler)
-        done()
-      })
-      document.body.dispatchEvent(new KeyboardEvent('keydown', {ctrlKey: true, code: 'KeyJ', key: 'j'}))
-    })
-
-    it('keydown with number', function (done) {
-      document.body.addEventListener('keydown', function handler(event) {
-        assert.equal(eventToHotkeyString(event), '1')
-        document.body.removeEventListener('keydown', handler)
-        done()
-      })
-      document.body.dispatchEvent(new KeyboardEvent('keydown', {key: '1'}))
-    })
-
-    it('keydown with symbol', function (done) {
-      document.body.addEventListener('keydown', function handler(event) {
-        assert.equal(eventToHotkeyString(event), 'Control+Shift+`')
-        document.body.removeEventListener('keydown', handler)
-        done()
-      })
-      document.body.dispatchEvent(new KeyboardEvent('keydown', {ctrlKey: true, shiftKey: true, key: '`'}))
-    })
+    }
   })
 
   describe('hotkey sequence support', function () {


### PR DESCRIPTION
This fixes a regression in the eventToHotkeyString function which was caused by trying to normalise the event.key toUpperCase. The regression was because on macos the "Meta+Shift" plane is always lowercase, which is contrary to other operating systems. This is a regression because that was expected behavior as part of this package, and the fix in `1.4.3` broke this expectation while trying to fix another bug.

This change respects the `event.key` spacing, and elides the shift key only when the event.key matches case, returning `Meta+Shift+p` as a viable shortcut.

/cc @jonrohan