### PR TITLE
Allow hotkey to be triggered when input or textfield is focused under certain conditions

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -8,7 +8,7 @@
 
 <body>
 
-  <button onclick="alert('clicked!')" data-hotkey="d">press d to click this button</button><br>
+  <button onclick="alert('clicked!')" data-hotkey="Meta+Shift+8,Control+Shift+8">press cmd+shift+8 or ctrl+shift+8 to click this button</button><br>
   <textarea data-hotkey="t" rows="4" cols="40">press t to focus on this field</textarea><br>
   <label><input data-hotkey="r" type="checkbox">Press r to check/uncheck this checkbox</label><br>
   <a href="#ok" data-hotkey="o k">Press <kbd>o k</kbd> click this link</a>

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import {Leaf, RadixTrie} from './radix-trie'
-import {fireDeterminedAction, expandHotkeyToEdges, isFormField} from './utils'
+import {fireDeterminedAction, expandHotkeyToEdges, isFormField, includesModifier} from './utils'
 import eventToHotkeyString from './hotkey'
 
 const hotkeyRadixTrie = new RadixTrie<HTMLElement>()
@@ -14,7 +14,8 @@ function resetTriePosition() {
 
 function keyDownHandler(event: KeyboardEvent) {
   if (event.defaultPrevented) return
-  if (event.target instanceof Node && isFormField(event.target)) return
+
+  if (event.target instanceof Node && isFormField(event.target) && !includesModifier(event)) return
 
   if (resetTriePositionTimer != null) {
     window.clearTimeout(resetTriePositionTimer)

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -24,3 +24,7 @@ export function fireDeterminedAction(el: HTMLElement): void {
 export function expandHotkeyToEdges(hotkey: string): string[][] {
   return hotkey.split(',').map(edge => edge.split(' '))
 }
+
+export function includesModifier(event: KeyboardEvent): boolean {
+  return event.altKey || event.ctrlKey || event.metaKey
+}

--- a/test/test.js
+++ b/test/test.js
@@ -76,6 +76,14 @@ describe('hotkey', function () {
       assert.deepEqual(elementsActivated, [])
     })
 
+    it('triggers when user is focused on a input or textfield and hotkey includes modifier', function () {
+      setHTML(`
+      <button id="button1" data-hotkey="Meta+7">Button 1</button>
+      <input id="textfield" />`)
+      document.getElementById('textfield').dispatchEvent(new KeyboardEvent('keydown', {metaKey: true, key: '7'}))
+      assert.include(elementsActivated, 'button1')
+    })
+
     it('handles multiple keys in a hotkey combination', function () {
       setHTML('<button id="button3" data-hotkey="Control+c">Button 3</button>')
       document.dispatchEvent(new KeyboardEvent('keydown', {key: 'c', ctrlKey: true}))


### PR DESCRIPTION
Relates to https://github.com/github/github/pull/193266

Currently we don't allow hotkeys to be triggered when the focus is on textfield or input.
We should allow hotkeys to be triggered as long as the hotkey involves a modifier.