### PR TITLE
Add support for scoped hotkey

### DIFF
--- a/examples/index.html
+++ b/examples/index.html
@@ -8,8 +8,8 @@
 
 <body>
 
-  <button onclick="alert('clicked!')" data-hotkey="d">press d to click this button</button><br>
-  <textarea data-hotkey="t" rows="4" cols="40">press t to focus on this field</textarea><br>
+  <button onclick="alert('clicked!')" data-hotkey-scope="text-area-1" data-hotkey="Control+d,Meta+d">press meta+d or ctrl+d in text area to click this button</button><br>
+  <textarea id="text-area-1" data-hotkey="t" rows="4" cols="40">press t to focus on this field</textarea><br>
   <label><input data-hotkey="r" type="checkbox">Press r to check/uncheck this checkbox</label><br>
   <a href="#ok" data-hotkey="o k">Press <kbd>o k</kbd> click this link</a>
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,8 +14,12 @@ function resetTriePosition() {
 
 function keyDownHandler(event: KeyboardEvent) {
   if (event.defaultPrevented) return
-  if (event.target instanceof Node && isFormField(event.target)) return
-
+  if (!(event.target instanceof Node)) return
+  if (isFormField(event.target)) {
+    const target = event.target as HTMLElement
+    if (!target.id) return
+    if (!target.ownerDocument.querySelector(`[data-hotkey-scope=${target.id}]`)) return
+  }
   if (resetTriePositionTimer != null) {
     window.clearTimeout(resetTriePositionTimer)
   }
@@ -31,10 +35,23 @@ function keyDownHandler(event: KeyboardEvent) {
 
   currentTriePosition = newTriePosition
   if (newTriePosition instanceof Leaf) {
-    fireDeterminedAction(newTriePosition.children[newTriePosition.children.length - 1])
-    event.preventDefault()
+    let shouldFire = true
+    const elementToFire = newTriePosition.children[newTriePosition.children.length - 1]
+    const hotkeyScope = elementToFire.getAttribute('data-hotkey-scope')
+    if (isFormField(event.target)) {
+      const target = event.target as HTMLElement
+      if (target.id !== elementToFire.getAttribute('data-hotkey-scope')) {
+        shouldFire = false
+      }
+    } else if (hotkeyScope) {
+      shouldFire = false
+    }
+
+    if (shouldFire) {
+      fireDeterminedAction(elementToFire)
+      event.preventDefault()
+    }
     resetTriePosition()
-    return
   }
 }
 

--- a/test/test.js
+++ b/test/test.js
@@ -96,12 +96,46 @@ describe('hotkey', function () {
     })
   })
 
+  describe('data-hotkey-scope', function () {
+    it('allows hotkey action from form field', function () {
+      setHTML(`
+      <button id="button1" data-hotkey-scope="textfield" data-hotkey="Meta+b">Button 1</button>
+      <input id="textfield" />`)
+      document
+        .getElementById('textfield')
+        .dispatchEvent(new KeyboardEvent('keydown', {bubbles: true, metaKey: true, cancelable: true, key: 'b'}))
+      assert.include(elementsActivated, 'button1')
+    })
+
+    it('does nothing if `data-hotkey-scope` is set to non-form field', function () {
+      setHTML(`
+      <button id="button1" data-hotkey-scope="button2" data-hotkey="Meta+b">Button 1</button>
+      <button id="button2" />`)
+      document
+        .getElementById('button2')
+        .dispatchEvent(new KeyboardEvent('keydown', {bubbles: true, metaKey: true, cancelable: true, key: 'b'}))
+      assert.deepEqual(elementsActivated, [])
+    })
+
+    it('does nothing if `data-hotkey-scope` does not exist', function () {
+      setHTML(`
+      <button id="button1" data-hotkey-scope="bad-id" data-hotkey="b">Button 1</button>
+      <input id="textfield" />`)
+      document
+        .getElementById('textfield')
+        .dispatchEvent(new KeyboardEvent('keydown', {bubbles: true, cancelable: true, key: 'b'}))
+      assert.deepEqual(elementsActivated, [])
+    })
+  })
+
   describe('eventToHotkeyString', function () {
     const tests = [
       ['Control+J', {ctrlKey: true, shiftKey: true, code: 'KeyJ', key: 'J'}],
       ['Control+Shift+j', {ctrlKey: true, shiftKey: true, code: 'KeyJ', key: 'j'}],
       ['Control+j', {ctrlKey: true, code: 'KeyJ', key: 'j'}],
       ['Meta+Shift+p', {key: 'p', metaKey: true, shiftKey: true, code: 'KeyP'}],
+      ['Meta+Shift+8', {key: '8', metaKey: true, shiftKey: true, code: 'Digit8'}],
+      ['Control+Shift+7', {key: '7', ctrlKey: true, shiftKey: true, code: 'Digit7'}],
       ['J', {shiftKey: true, code: 'KeyJ', key: 'J'}],
       ['/', {key: '/', code: ''}],
       ['1', {key: '1', code: 'Digit1'}],


### PR DESCRIPTION
#### What
Add support for scoped hotkeys when the `data-hotkey-scope` attribute is specified.

For example: 

```.html
<!-- button click can only be triggered when hotkey is pressed from textarea#text-area-1 -->
<button data-hotkey="Control+P" data-hotkey-scope="text-area-1"> Button 1 </button>
<textarea id="text-area-1"> </textarea>
<textarea id="text-area-2"> </textarea>
```

#### Why
Currently `github/hotkey` only supports global hotkeys but increasingly we are seeing a need for hotkey actions that can be triggered from a textarea.  Rather than relying on custom hotkey implementations for scoped shortcuts, we should expand this library.

 Co-authored-by: @keithamus