### PR TITLE
build: auto publish releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,54 @@
+name: Publish
+
+on:
+  release:
+    types: [created]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm test
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          registry-url: https://registry.npmjs.org/
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm version ${TAG_NAME} --git-tag-version=false
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.npm_token}}
+  publish-gpr:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 14
+          registry-url: https://npm.pkg.github.com/
+      - run: npm ci
+      - run: npm run build --if-present
+      - run: npm version ${TAG_NAME} --git-tag-version=false
+        env:
+          TAG_NAME: ${{ github.event.release.tag_name }}
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
### What?

Add a CI script to publish packages automatically for us.

### Why?

We've had difficulty in the past with publishing things in a reliable way. Forcing devs to publish on their local machines can mean all sorts of things:

 - Perhaps they fail to run a command like `npm ci` which means deps are out of date, if compiling code this can affect the published artefact.
 - Perhaps they've got extra files in their repository such as editor session files or notes files or unstaged files - this can sometimes accidentally get included
 - We aren't always the best at setting up the dual-publish workflow, publishing to both GPR and npm. So some packages get inconsistently published to one or the other.
 - Publishing packages can be scary! What if I missed something? It's a nerve wracking experience!

Additional pains can be:
 - We have to provision entitlements. As new people join they need to be set up on github/npm, as people depart they need to be removed reliably. More systems to maintain

All of these issues can be solved by simply getting the computer to do it. In this case GitHub Actions. It gives us:
 - A reliable and repeatable environment
 - A single user/scope/authority to publish from
 - An easy user interface to handle publishes from (the GitHub Releases page)

### How?

This CI script will, on creation of a GitHub release:

 - Install deps with `npm ci`
 - Run tests just to make sure this release is A-OK
 - Set the package.json version to the releases tag
 - Publish to both npm and GPR

If we like this idea we can push this out to all other repos.

### Tradeoffs

One downside to this particular style of doing things is that the in-version-control `package.json#version` key will be out of sync with what is published. [On projects where I automate this I set that key to `0.0.0-dev` so people know something funky is going on](https://github.com/keithamus/sort-package-json/blob/master/package.json#L3).