### PR TITLE
feat: dispatch event on fireDeterminedAction

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,8 +6,10 @@ const hotkeyRadixTrie = new RadixTrie<HTMLElement>()
 const elementsLeaves = new WeakMap<HTMLElement, Array<Leaf<HTMLElement>>>()
 let currentTriePosition: RadixTrie<HTMLElement> | Leaf<HTMLElement> = hotkeyRadixTrie
 let resetTriePositionTimer: number | null = null
+let path: string[] = []
 
 function resetTriePosition() {
+  path = []
   resetTriePositionTimer = null
   currentTriePosition = hotkeyRadixTrie
 }
@@ -32,6 +34,7 @@ function keyDownHandler(event: KeyboardEvent) {
     resetTriePosition()
     return
   }
+  path.push(eventToHotkeyString(event))
 
   currentTriePosition = newTriePosition
   if (newTriePosition instanceof Leaf) {
@@ -50,7 +53,7 @@ function keyDownHandler(event: KeyboardEvent) {
     }
 
     if (elementToFire && shouldFire) {
-      fireDeterminedAction(elementToFire)
+      fireDeterminedAction(elementToFire, path)
       event.preventDefault()
     }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,7 +13,10 @@ export function isFormField(element: Node): boolean {
   )
 }
 
-export function fireDeterminedAction(el: HTMLElement): void {
+export function fireDeterminedAction(el: HTMLElement, detail: string[]): void {
+  const delegateEvent = new CustomEvent('hotkey-fire', {cancelable: true, detail})
+  const cancelled = !el.dispatchEvent(delegateEvent)
+  if (cancelled) return
   if (isFormField(el)) {
     el.focus()
   } else {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -13,8 +13,8 @@ export function isFormField(element: Node): boolean {
   )
 }
 
-export function fireDeterminedAction(el: HTMLElement, detail: string[]): void {
-  const delegateEvent = new CustomEvent('hotkey-fire', {cancelable: true, detail})
+export function fireDeterminedAction(el: HTMLElement, path: string[]): void {
+  const delegateEvent = new CustomEvent('hotkey-fire', {cancelable: true, detail: {path}})
   const cancelled = !el.dispatchEvent(delegateEvent)
   if (cancelled) return
   if (isFormField(el)) {

--- a/test/test.js
+++ b/test/test.js
@@ -100,7 +100,7 @@ describe('hotkey', function () {
       let fired = false
       document.querySelector('#button1').addEventListener('hotkey-fire', event => {
         fired = true
-        assert.deepEqual(event.detail, ['B'])
+        assert.deepEqual(event.detail.path, ['B'])
         assert.equal(event.cancelable, true)
       })
       document.dispatchEvent(new KeyboardEvent('keydown', {shiftKey: true, code: 'KeyB', key: 'B'}))
@@ -179,7 +179,7 @@ describe('hotkey', function () {
       let fired = false
       document.querySelector('#button1').addEventListener('hotkey-fire', event => {
         fired = true
-        assert.deepEqual(event.detail, ['Meta+b'])
+        assert.deepEqual(event.detail.path, ['Meta+b'])
         assert.equal(event.cancelable, true)
       })
       document
@@ -262,7 +262,7 @@ describe('hotkey', function () {
       let fired = false
       document.querySelector('#link3').addEventListener('hotkey-fire', event => {
         fired = true
-        assert.deepEqual(event.detail, ['d', 'e', 'f'])
+        assert.deepEqual(event.detail.path, ['d', 'e', 'f'])
         assert.equal(event.cancelable, true)
       })
       await keySequence('d e f')

--- a/test/test.js
+++ b/test/test.js
@@ -94,6 +94,25 @@ describe('hotkey', function () {
       document.dispatchEvent(new KeyboardEvent('keydown', {shiftKey: true, code: 'KeyB', key: 'B'}))
       assert.include(elementsActivated, 'button1')
     })
+
+    it('dispatches an event on the element once fired', function () {
+      setHTML('<button id="button1" data-hotkey="B">Button 1</button>')
+      let fired = false
+      document.querySelector('#button1').addEventListener('hotkey-fire', event => {
+        fired = true
+        assert.deepEqual(event.detail, ['B'])
+        assert.equal(event.cancelable, true)
+      })
+      document.dispatchEvent(new KeyboardEvent('keydown', {shiftKey: true, code: 'KeyB', key: 'B'}))
+      assert.ok(fired, 'button1 did not receive a hotkey-fire event')
+    })
+
+    it('wont trigger action if the hotkey-fire event is cancelled', function () {
+      setHTML('<button id="button1" data-hotkey="B">Button 1</button>')
+      document.querySelector('#button1').addEventListener('hotkey-fire', event => event.preventDefault())
+      document.dispatchEvent(new KeyboardEvent('keydown', {shiftKey: true, code: 'KeyB', key: 'B'}))
+      assert.notInclude(elementsActivated, 'button1')
+    })
   })
 
   describe('data-hotkey-scope', function () {
@@ -148,6 +167,41 @@ describe('hotkey', function () {
       document.dispatchEvent(new KeyboardEvent('keydown', keyboardEventArgs))
       assert.include(elementsActivated, 'button3')
     })
+
+    it('dispatches an event on the element once fired', function () {
+      setHTML(`
+      <button id="button1" data-hotkey-scope="textfield1" data-hotkey="Meta+b">Button 1</button>
+      <input id="textfield1" />
+      <button id="button2" data-hotkey-scope="textfield2" data-hotkey="Meta+b">Button 2</button>
+      <input id="textfield2" />
+      <button id="button3" data-hotkey="Meta+b">Button 2</button>
+      `)
+      let fired = false
+      document.querySelector('#button1').addEventListener('hotkey-fire', event => {
+        fired = true
+        assert.deepEqual(event.detail, ['Meta+b'])
+        assert.equal(event.cancelable, true)
+      })
+      document
+        .getElementById('textfield1')
+        .dispatchEvent(new KeyboardEvent('keydown', {bubbles: true, metaKey: true, cancelable: true, key: 'b'}))
+      assert.ok(fired, 'button1 did not receive a hotkey-fire event')
+    })
+
+    it('wont trigger action if the hotkey-fire event is cancelled', function () {
+      setHTML(`
+      <button id="button1" data-hotkey-scope="textfield1" data-hotkey="Meta+b">Button 1</button>
+      <input id="textfield1" />
+      <button id="button2" data-hotkey-scope="textfield2" data-hotkey="Meta+b">Button 2</button>
+      <input id="textfield2" />
+      <button id="button3" data-hotkey="Meta+b">Button 2</button>
+      `)
+      document.querySelector('#button1').addEventListener('hotkey-fire', event => event.preventDefault())
+      document
+        .getElementById('textfield1')
+        .dispatchEvent(new KeyboardEvent('keydown', {bubbles: true, metaKey: true, cancelable: true, key: 'b'}))
+      assert.notInclude(elementsActivated, 'button1')
+    })
   })
 
   describe('eventToHotkeyString', function () {
@@ -201,6 +255,18 @@ describe('hotkey', function () {
       setHTML('<a id="exact" href="#" data-hotkey="j k"></a>')
       await keySequence('j z k')
       assert.deepEqual(elementsActivated, [])
+    })
+
+    it('dispatches an event on the element once fired', async function () {
+      setHTML('<a id="link3" href="#" data-hotkey="d e f"></a>')
+      let fired = false
+      document.querySelector('#link3').addEventListener('hotkey-fire', event => {
+        fired = true
+        assert.deepEqual(event.detail, ['d', 'e', 'f'])
+        assert.equal(event.cancelable, true)
+      })
+      await keySequence('d e f')
+      assert.ok(fired, 'link3 did not receive a hotkey-fire event')
     })
   })
 


### PR DESCRIPTION
This adds a new event: `hotkey-fire` which is dispatched on the element to fire (non bubbling, cancelable).

If it is cancelled the default action of click/focus is not triggered, which leaves developers to implement their own behaviour with some custom JS.

The point of this feature is that we can add `data-hotkey` to other types of elements than just form controls and buttons/links and trigger custom behaviours, while delegating/centralising the hotkey behaviour to this library. By listening to this event instead of `keydown` we can bind to advanced sequential keyboard shortcuts.