### PR TITLE
Fix querySelector by quoting templated value

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -20,7 +20,7 @@ function keyDownHandler(event: KeyboardEvent) {
   if (isFormField(event.target)) {
     const target = event.target as HTMLElement
     if (!target.id) return
-    if (!target.ownerDocument.querySelector(`[data-hotkey-scope=${target.id}]`)) return
+    if (!target.ownerDocument.querySelector(`[data-hotkey-scope="${target.id}"]`)) return
   }
   if (resetTriePositionTimer != null) {
     window.clearTimeout(resetTriePositionTimer)


### PR DESCRIPTION
For some elements which have invalid query selector values in the ID, for example a space character, having the id selector unquoted will cause a DOMException. This is easily mitigated by wrapping this selector in quotes.