### PR TITLE
Add tool to generate correct hotkey string for a given key combination

### DIFF
--- a/examples/hotkey_mapper.html
+++ b/examples/hotkey_mapper.html
@@ -18,14 +18,14 @@
   <div class="blankslate mx-auto col-12 col-md-8 col-lg-6 col-xl-4">
     <h1>Hotkey Code</h1>
     <p>Type your desired key combination on the keyboard to see the corresponding Hotkey string.</p>
-    <div class="mb-n6 ml-auto p-1 text-right">
-      <clipboard-copy for="hotkey-code" class="width-full">
+    <div class="position-relative">
+      <clipboard-copy for="hotkey-code" class="position-absolute top-2 right-2">
         <button aria-label="Copy to clipboard" class="btn">
           <svg aria-hidden="true" role="img" class="StyledOcticon-uhnt7w-0 iIOaoH" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" style="display:inline-block;user-select:none;vertical-align:text-bottom;overflow:visible"><path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"></path><path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"></path></svg>
         </button>
       </clipboard-copy>
+      <div id="hotkey-code" class="border rounded-2 p-6 f1 text-mono">&nbsp;</div>
     </div>
-    <div id="hotkey-code" class="border rounded-2 p-6 f1 text-mono">&nbsp;</div>
   </div>
 
   <script type="module">

--- a/examples/hotkey_mapper.html
+++ b/examples/hotkey_mapper.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width">
+  <title>hotkey demo</title>
+  <link href="https://unpkg.com/@primer/css@^16.0.0/dist/primer.css" rel="stylesheet" />
+</head>
+
+<body>
+  <div class="blankslate mx-auto col-12 col-md-8 col-lg-6 col-xl-4">
+    <h1>Hotkey Code</h1>
+    <p>Type your desired key combination on the keyboard to see the corresponding Hotkey string.</p>
+    <div id="hotkey-code" class="border rounded-2 p-6 f1 text-mono">&nbsp;</div>
+    <div id="history" />
+  </div>
+
+  <script type="module">
+    // import {eventToHotkeyString} from '../dist/index.js'
+    import {eventToHotkeyString} from 'https://unpkg.com/@github/hotkey@latest?module';
+    const codeInput = document.getElementById('hotkey-code');
+    document.addEventListener('keydown', event => {
+      const code = eventToHotkeyString(event);
+      console.log(`Hotkey Code is: "${code}"`);
+      codeInput.innerText = code;
+      event.preventDefault();
+      event.stopPropagation();
+    })
+  </script>
+</body>
+
+</html>

--- a/examples/hotkey_mapper.html
+++ b/examples/hotkey_mapper.html
@@ -4,16 +4,28 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
-  <title>hotkey demo</title>
+  <title>Hotkey Mapper Tool</title>
   <link href="https://unpkg.com/@primer/css@^16.0.0/dist/primer.css" rel="stylesheet" />
+  <script type="module" src="https://unpkg.com/@github/clipboard-copy-element@latest?module"></script>
+  <style>
+    .copy {
+      /* marg */
+    }
+  </style>
 </head>
 
 <body>
   <div class="blankslate mx-auto col-12 col-md-8 col-lg-6 col-xl-4">
     <h1>Hotkey Code</h1>
     <p>Type your desired key combination on the keyboard to see the corresponding Hotkey string.</p>
+    <div class="mb-n6 ml-auto p-1 text-right">
+      <clipboard-copy for="hotkey-code" class="width-full">
+        <button aria-label="Copy to clipboard" class="btn">
+          <svg aria-hidden="true" role="img" class="StyledOcticon-uhnt7w-0 iIOaoH" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" style="display:inline-block;user-select:none;vertical-align:text-bottom;overflow:visible"><path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"></path><path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"></path></svg>
+        </button>
+      </clipboard-copy>
+    </div>
     <div id="hotkey-code" class="border rounded-2 p-6 f1 text-mono">&nbsp;</div>
-    <div id="history" />
   </div>
 
   <script type="module">


### PR DESCRIPTION
relates to #54

This PR adds a tool to the `/examples` folder that allows a user to determine the correct hotkey string (as returned from `eventToHotKeyString`) for the given key combination. This tool could be a useful reference for users wanting to determine the correct hotkey string for their shortcut.

See the attached screen cast of the tool in action:



https://user-images.githubusercontent.com/2694/146098224-dfbd7a0c-9caa-470f-b81f-f850b3b56cbf.mov



