### PR TITLE
Update hotkey README to document hotkey string format

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Hotkey Behavior
 
+```html
+<button data-hotkey="Shift+?">Show help dialog</button>
+```
+
 Trigger an action on a target element when a key or sequence of keys is pressed
 on the keyboard. This triggers a focus event on form fields, or a click event on
 others.

--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ The following hotkey would match if the user typed the key sequence `a` and then
 
 🔬 **Hotkey Mapper** is a tool to help you determine the correct hotkey string for your key combination: https://github.github.io/hotkey/examples/hotkey_mapper.html
 
-#### Keypress sequence considerations
+#### Key-sequence considerations
 
-Two-keypress sequences such as `g c` and `g i` are stored
+Two-key-sequences such as `g c` and `g i` are stored
 under the 'g' key in a nested object with 'c' and 'i' keys.
 
 ```

--- a/README.md
+++ b/README.md
@@ -11,59 +11,6 @@ other elements.
 By default, hotkeys are extracted from a target element's `data-hotkey`
 attribute, but this can be overridden by passing the hotkey to the registering
 function (`install`) as a parameter.
-
-#### Hotkey string format
-
-1. Hotkey matches against the `event.key`, and uses standard W3C key names for keys and modifiers as documented in [UI Events KeyboardEvent key Values](https://www.w3.org/TR/uievents-key/).
-2. At minimum a hotkey string must specify one bare key.
-3. Multiple hotkeys (aliases) are separated by a `,`. For example the hotkey `a,b` would activate if the user typed `a` or `b`.
-4. Multiple keys separated by a blank space represent a key sequence. For example the hotkey `g n` would activate when a user types the `g` key followed by the `n` key.
-5. Modifier key combos are separated with a `+` and are prepended to a key in a consistent order as follows: `Control+Alt+Meta+Shift+KEY`.
-
-##### Example
-
-The following hotkey would match if the user typed the key sequence `a` and then `b`, OR if the user held down the `Control`, `Alt` and `/` keys at the same time.
-
-```js
-"a b,Control+Alt+/"
-```
-
-🔬 **Hotkey Mapper** is a tool to help you determine the correct hotkey string for your key combination: https://github.github.io/hotkey/examples/hotkey_mapper.html
-
-#### Key-sequence considerations
-
-Two-key-sequences such as `g c` and `g i` are stored
-under the 'g' key in a nested object with 'c' and 'i' keys.
-
-```
-mappings =
-  'c'     : <a href="/rails/rails/issues/new" data-hotkey="c">New Issue</a>
-  'g'     :
-    'c'   : <a href="/rails/rails" data-hotkey="g c">Code</a>
-    'i'   : <a href="/rails/rails/issues" data-hotkey="g i">Issues</a>
-```
-
-In this example, both `g c` and `c` could be available as hotkeys on the
-same page, but `g c` and `g` can't coexist. If the user presses
-`g`, the `c` hotkey will be unavailable for 1500 ms while we
-wait for either `g c` or `g i`.
-
-## Accessibility considerations
-
-### Character Key Shortcuts
-
-Please note that adding this functionality to your site can be a drawback for
-certain users. Providing a way in your system to disable hotkeys or remap
-them makes sure that those users can still use your site (given that it's
-accessible to those users).
-
-See ["Understanding Success Criterion 2.1.4: Character Key Shortcuts"](https://www.w3.org/WAI/WCAG21/Understanding/character-key-shortcuts.html)
-for further reading on this topic.
-
-### Interactive Elements
-
-Wherever possible, hotkeys should be add to [interactive and focusable elements](https://html.spec.whatwg.org/#interactive-content). If a static element must be used, please follow the guideline in ["Adding keyboard-accessible actions to static HTML elements"](https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR29.html).
-
 ## Installation
 
 ```
@@ -110,6 +57,58 @@ for (const el of document.querySelectorAll('[data-hotkey]')) {
   uninstall(el)
 }
 ```
+
+## Hotkey string format
+
+1. Hotkey matches against the `event.key`, and uses standard W3C key names for keys and modifiers as documented in [UI Events KeyboardEvent key Values](https://www.w3.org/TR/uievents-key/).
+2. At minimum a hotkey string must specify one bare key.
+3. Multiple hotkeys (aliases) are separated by a `,`. For example the hotkey `a,b` would activate if the user typed `a` or `b`.
+4. Multiple keys separated by a blank space represent a key sequence. For example the hotkey `g n` would activate when a user types the `g` key followed by the `n` key.
+5. Modifier key combos are separated with a `+` and are prepended to a key in a consistent order as follows: `Control+Alt+Meta+Shift+KEY`.
+
+### Example
+
+The following hotkey would match if the user typed the key sequence `a` and then `b`, OR if the user held down the `Control`, `Alt` and `/` keys at the same time.
+
+```js
+"a b,Control+Alt+/"
+```
+
+🔬 **Hotkey Mapper** is a tool to help you determine the correct hotkey string for your key combination: https://github.github.io/hotkey/examples/hotkey_mapper.html
+
+#### Key-sequence considerations
+
+Two-key-sequences such as `g c` and `g i` are stored
+under the 'g' key in a nested object with 'c' and 'i' keys.
+
+```
+mappings =
+  'c'     : <a href="/rails/rails/issues/new" data-hotkey="c">New Issue</a>
+  'g'     :
+    'c'   : <a href="/rails/rails" data-hotkey="g c">Code</a>
+    'i'   : <a href="/rails/rails/issues" data-hotkey="g i">Issues</a>
+```
+
+In this example, both `g c` and `c` could be available as hotkeys on the
+same page, but `g c` and `g` can't coexist. If the user presses
+`g`, the `c` hotkey will be unavailable for 1500 ms while we
+wait for either `g c` or `g i`.
+
+## Accessibility considerations
+
+### Character Key Shortcuts
+
+Please note that adding this functionality to your site can be a drawback for
+certain users. Providing a way in your system to disable hotkeys or remap
+them makes sure that those users can still use your site (given that it's
+accessible to those users).
+
+See ["Understanding Success Criterion 2.1.4: Character Key Shortcuts"](https://www.w3.org/WAI/WCAG21/Understanding/character-key-shortcuts.html)
+for further reading on this topic.
+
+### Interactive Elements
+
+Wherever possible, hotkeys should be add to [interactive and focusable elements](https://html.spec.whatwg.org/#interactive-content). If a static element must be used, please follow the guideline in ["Adding keyboard-accessible actions to static HTML elements"](https://www.w3.org/WAI/WCAG21/Techniques/client-side-script/SCR29.html).
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ function (`install`) as a parameter.
 
 ## How is this used on GitHub?
 
-All shortcuts (for example `g i`, `.`, `Meta+Shift+k`) within GitHub use this feature to declare the shortcut in server side templates. This is used on almost every page on GitHub.
+All shortcuts (for example `g i`, `.`, `Meta+k`) within GitHub use hotkey to declare shortcuts in server side templates. This is used on almost every page on GitHub.
+
 ## Installation
 
 ```

--- a/README.md
+++ b/README.md
@@ -11,6 +11,10 @@ other elements.
 By default, hotkeys are extracted from a target element's `data-hotkey`
 attribute, but this can be overridden by passing the hotkey to the registering
 function (`install`) as a parameter.
+
+## How is this used on GitHub?
+
+All shortcuts (for example `g i`, `.`, `Meta+Shift+k`) within GitHub use this feature to declare the shortcut in server side templates. This is used on almost every page on GitHub.
 ## Installation
 
 ```

--- a/README.md
+++ b/README.md
@@ -4,16 +4,33 @@
 <button data-hotkey="Shift+?">Show help dialog</button>
 ```
 
-Trigger an action on a target element when a key or sequence of keys is pressed
+Trigger an action on a target element when a key, or sequence of keys, is pressed
 on the keyboard. This triggers a focus event on form fields, or a click event on
-others.
+other elements.
 
 By default, hotkeys are extracted from a target element's `data-hotkey`
 attribute, but this can be overridden by passing the hotkey to the registering
 function (`install`) as a parameter.
 
-Multiple hotkeys are separated by a `,`; key combinations are separated
-by a `+`; and key sequences are separated by a space.
+#### Hotkey string format
+
+1. Hotkey matches against the `event.key`, and uses standard W3C key names for keys and modifiers as documented in [UI Events KeyboardEvent key Values](https://www.w3.org/TR/uievents-key/).
+2. At minimum a hotkey string must specify one bare key.
+3. Multiple hotkeys (aliases) are separated by a `,`. For example the hotkey `a,b` would activate if the user typed `a` or `b`.
+4. Multiple keys separated by a blank space represent a key sequence. For example the hotkey `g n` would activate when a user types the `g` key followed by the `n` key.
+5. Modifier key combos are separated with a `+` and are prepended to a key in a consistent order as follows: `Control+Alt+Meta+Shift+KEY`.
+
+##### Example
+
+The following hotkey would match if the user typed the key sequence `a` and then `b`, OR if the user held down the `Control`, `Alt` and `/` keys at the same time.
+
+```js
+"a b,Control+Alt+/"
+```
+
+🔬 **Hotkey Mapper** is a tool to help you determine the correct hotkey string for your key combination: https://github.github.io/hotkey/examples/hotkey_mapper.html
+
+#### Keypress sequence considerations
 
 Two-keypress sequences such as `g c` and `g i` are stored
 under the 'g' key in a nested object with 'c' and 'i' keys.
@@ -54,7 +71,6 @@ $ npm install @github/hotkey
 ```
 
 ## Usage
-
 ### HTML
 
 ``` html

--- a/examples/hotkey_mapper.html
+++ b/examples/hotkey_mapper.html
@@ -15,7 +15,7 @@
 </head>
 
 <body>
-  <div class="blankslate mx-auto col-12 col-md-8 col-lg-6 col-xl-4">
+  <div class="blankslate mx-auto col-12 col-md-8 col-lg-6">
     <h1>Hotkey Code</h1>
     <p>Type your desired key combination on the keyboard to see the corresponding Hotkey string.</p>
     <div class="position-relative">
@@ -24,7 +24,7 @@
           <svg aria-hidden="true" role="img" class="StyledOcticon-uhnt7w-0 iIOaoH" viewBox="0 0 16 16" width="16" height="16" fill="currentColor" style="display:inline-block;user-select:none;vertical-align:text-bottom;overflow:visible"><path fill-rule="evenodd" d="M0 6.75C0 5.784.784 5 1.75 5h1.5a.75.75 0 010 1.5h-1.5a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-1.5a.75.75 0 011.5 0v1.5A1.75 1.75 0 019.25 16h-7.5A1.75 1.75 0 010 14.25v-7.5z"></path><path fill-rule="evenodd" d="M5 1.75C5 .784 5.784 0 6.75 0h7.5C15.216 0 16 .784 16 1.75v7.5A1.75 1.75 0 0114.25 11h-7.5A1.75 1.75 0 015 9.25v-7.5zm1.75-.25a.25.25 0 00-.25.25v7.5c0 .138.112.25.25.25h7.5a.25.25 0 00.25-.25v-7.5a.25.25 0 00-.25-.25h-7.5z"></path></svg>
         </button>
       </clipboard-copy>
-      <div id="hotkey-code" class="border rounded-2 p-6 f1 text-mono">&nbsp;</div>
+      <div id="hotkey-code" class="border rounded-2 p-6 f1 text-mono overflow-auto">&nbsp;</div>
     </div>
   </div>
 


### PR DESCRIPTION
This PR adds a more detailed section documenting the hotkey string grammar. It also does a few other things:

1. Adds a simple example of usage at the very top as a TLDR
1. Swaps the order of the "Basic" usage (HTML and JS) and the more advanced topics like hotkey string format and accessibility. 
2. links to the Hotkey Mapper tool.
2. Fixes a layout issue in the Hotkey Mapper tool.

You can see the updated REAME here https://github.com/github/hotkey/blob/41c95f103f6e61e47ec43a83bae8edb30bc980e9/README.md
