### PR TITLE
fixes `eventToHotkeyString` returns doubled "modifier" when "key" is a modifier

### DIFF
--- a/src/hotkey.ts
+++ b/src/hotkey.ts
@@ -25,14 +25,14 @@
 //
 // Returns key character String or null.
 export default function hotkey(event: KeyboardEvent): string {
-  const {ctrlKey, altKey, metaKey, shiftKey, key, code} = event
+  const {ctrlKey, altKey, metaKey, key} = event
+  const hotkeyString = []
 
-  // We don't want to show `Shift` when key is capital
-  const showShift = shiftKey && !(code.startsWith('Key') && key.toUpperCase() === key)
+  const modifiers = [ctrlKey, altKey, metaKey, showShift(event)]
 
-  const hotkeyString = [ctrlKey, altKey, metaKey, showShift]
-    .map((modifier, i) => (modifier === true ? modifierKeys[i] : null))
-    .filter(modifier => modifier !== null)
+  for (const mod of modifiers) {
+    if (mod) hotkeyString.push(mod)
+  }
 
   if (!modifierKeys.includes(key)) {
     hotkeyString.push(key)
@@ -42,3 +42,9 @@ export default function hotkey(event: KeyboardEvent): string {
 }
 
 const modifierKeys = [`Control`, 'Alt', 'Meta', 'Shift']
+
+// We don't want to show `Shift` when key is capital
+function showShift(event: KeyboardEvent) {
+  const {shiftKey, code, key} = event
+  return shiftKey && !(code.startsWith('Key') && key.toUpperCase() === key)
+}

--- a/src/hotkey.ts
+++ b/src/hotkey.ts
@@ -26,25 +26,24 @@
 // Returns key character String or null.
 export default function hotkey(event: KeyboardEvent): string {
   const {ctrlKey, altKey, metaKey, key} = event
-  const hotkeyString = []
+  const hotkeyString: string[] = []
+  const modifiers: boolean[] = [ctrlKey, altKey, metaKey, showShift(event)]
 
-  const modifiers = [ctrlKey, altKey, metaKey, showShift(event)]
-
-  for (const mod of modifiers) {
-    if (mod) hotkeyString.push(mod)
+  for (const [i, mod] of modifiers.entries()) {
+    if (mod) hotkeyString.push(modifierKeyNames[i])
   }
 
-  if (!modifierKeys.includes(key)) {
+  if (!modifierKeyNames.includes(key)) {
     hotkeyString.push(key)
   }
 
   return hotkeyString.join('+')
 }
 
-const modifierKeys = [`Control`, 'Alt', 'Meta', 'Shift']
+const modifierKeyNames: string[] = [`Control`, 'Alt', 'Meta', 'Shift']
 
-// We don't want to show `Shift` when key is capital
-function showShift(event: KeyboardEvent) {
+// We don't want to show `Shift` when `event.key` is capital
+function showShift(event: KeyboardEvent): boolean {
   const {shiftKey, code, key} = event
   return shiftKey && !(code.startsWith('Key') && key.toUpperCase() === key)
 }

--- a/src/hotkey.ts
+++ b/src/hotkey.ts
@@ -25,8 +25,20 @@
 //
 // Returns key character String or null.
 export default function hotkey(event: KeyboardEvent): string {
-  const elideShift = event.code.startsWith('Key') && event.shiftKey && event.key.toUpperCase() === event.key
-  return `${event.ctrlKey ? 'Control+' : ''}${event.altKey ? 'Alt+' : ''}${event.metaKey ? 'Meta+' : ''}${
-    event.shiftKey && !elideShift ? 'Shift+' : ''
-  }${event.key}`
+  const {ctrlKey, altKey, metaKey, shiftKey, key, code} = event
+
+  // We don't want to show `Shift` when key is capital
+  const showShift = shiftKey && !(code.startsWith('Key') && key.toUpperCase() === key)
+
+  const hotkeyString = [ctrlKey, altKey, metaKey, showShift]
+    .map((modifier, i) => (modifier === true ? modifierKeys[i] : null))
+    .filter(modifier => modifier !== null)
+
+  if (!modifierKeys.includes(key)) {
+    hotkeyString.push(key)
+  }
+
+  return hotkeyString.join('+')
 }
+
+const modifierKeys = [`Control`, 'Alt', 'Meta', 'Shift']

--- a/test/test.js
+++ b/test/test.js
@@ -218,7 +218,9 @@ describe('hotkey', function () {
       ['Control+Shift+`', {ctrlKey: true, shiftKey: true, key: '`'}],
       ['c', {key: 'c', code: 'KeyC'}],
       ['S', {key: 'S', shiftKey: true, code: 'KeyS'}],
-      ['!', {key: '!', shiftKey: true, code: 'KeyS'}]
+      ['!', {key: '!', shiftKey: true, code: 'KeyS'}],
+      ['Control+Shift', {ctrlKey: true, shiftKey: true, key: 'Shift'}],
+      ['Control+Shift', {ctrlKey: true, shiftKey: true, key: 'Control'}]
     ]
     for (const [expected, keyEvent] of tests) {
       it(`${JSON.stringify(keyEvent)} => ${expected}`, function (done) {


### PR DESCRIPTION
resolves #60 

This PR fixes a bug where `eventToHotkeyString` was returning a "double modifier" for a key-combination where a modifier key (`Control`, `Alt`, `Meta`, or `Shift`) is also the `event.key`.

This PR updates `eventToHotkeyString` so that the resulting string still presents modifiers in a consistent order. 

For more details see #60 

| Before | After |
| ---| --- |
| <img width="712" alt="Screen Shot 2021-12-15 at 9 50 36 AM" src="https://user-images.githubusercontent.com/2694/146208754-ed8f8cc9-3c86-4e7c-9aa5-c21c20d2da08.png"> | <img width="670" alt="Screen Shot 2021-12-16 at 5 58 21 PM" src="https://user-images.githubusercontent.com/2694/146461256-15289492-7e1e-4ec4-806f-3c8359877fe5.png"> |

## Screencast of the after

https://user-images.githubusercontent.com/2694/146461487-c3832946-788c-47be-a3f3-eadfe712a5e7.mov

## Breaking change

Although the previous behaviour was likely a bug, this is a breaking change in that it changes the "hotkey string" format when a modifier key is used as the `hotkey` (the final element in a hotkey string sequence) for example `Meta+Shift+Shift` becomes `Meta+Shift` after this change.


