### PR TITLE
Allow hotkeys when focusing on `file` input elements

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -8,7 +8,12 @@ export function isFormField(element: Node): boolean {
   return (
     name === 'select' ||
     name === 'textarea' ||
-    (name === 'input' && type !== 'submit' && type !== 'reset' && type !== 'checkbox' && type !== 'radio') ||
+    (name === 'input' &&
+      type !== 'submit' &&
+      type !== 'reset' &&
+      type !== 'checkbox' &&
+      type !== 'radio' &&
+      type !== 'file') ||
     element.isContentEditable
   )
 }

--- a/test/test.js
+++ b/test/test.js
@@ -72,8 +72,16 @@ describe('hotkey', function () {
       setHTML(`
       <button id="button1" data-hotkey="b">Button 1</button>
       <input id="textfield" />`)
-      document.getElementById('textfield').dispatchEvent(new KeyboardEvent('keydown', {key: 'b'}))
+      document.getElementById('textfield').dispatchEvent(new KeyboardEvent('keydown', {bubbles: true, key: 'b'}))
       assert.deepEqual(elementsActivated, [])
+    })
+
+    it('triggers when user is focused on a file input', function () {
+      setHTML(`
+      <button id="button1" data-hotkey="b">Button 1</button>
+      <input id="filefield" type="file" />`)
+      document.getElementById('filefield').dispatchEvent(new KeyboardEvent('keydown', {bubbles: true, key: 'b'}))
+      assert.deepEqual(elementsActivated, ['button1'])
     })
 
     it('handles multiple keys in a hotkey combination', function () {


### PR DESCRIPTION
I would like to allow hotkeys when focusing on `file` input elements by updating `isFormField` to return false for input elements with type `file`. 

`file` inputs are similar to `submit` or `radio` where a user needs to click on them for some interaction and can't freely type text. Therefore it should be fine to allow hotkeys when focused this kind of input.
