### PR TITLE
Add npm package provenance in release workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,6 +4,10 @@ on:
   release:
     types: [created]
 
+permissions:
+  contents: read
+  id-token: write
+
 jobs:
   publish-npm:
     runs-on: ubuntu-latest
@@ -19,6 +23,6 @@ jobs:
       - run: npm version ${TAG_NAME} --git-tag-version=false
         env:
           TAG_NAME: ${{ github.event.release.tag_name }}
-      - run: npm whoami; npm --ignore-scripts publish
+      - run: npm whoami; npm --ignore-scripts publish --provenance
         env:
           NODE_AUTH_TOKEN: ${{secrets.npm_token}}


### PR DESCRIPTION
Noticed that we aren't publishing [provenance](https://github.blog/2023-04-19-introducing-npm-package-provenance/) with the releases (probably because we haven't released since it was introduced 🙂). It's easy to set up so I figured I'd just do it so we can have it in `2.2`.