### PR TITLE
Make `NormalizedHotkeyString` extend `NormalizedSequenceString`

### DIFF
--- a/src/hotkey.ts
+++ b/src/hotkey.ts
@@ -1,3 +1,5 @@
+import {NormalizedSequenceString} from './sequence'
+
 const normalizedHotkeyBrand = Symbol('normalizedHotkey')
 
 /**
@@ -17,7 +19,7 @@ const normalizedHotkeyBrand = Symbol('normalizedHotkey')
  * "Control+s"          // Control modifier plus letter
  * "Control+Alt+Delete" // Multiple modifiers
  */
-export type NormalizedHotkeyString = string & {[normalizedHotkeyBrand]: true}
+export type NormalizedHotkeyString = NormalizedSequenceString & {[normalizedHotkeyBrand]: true}
 
 /**
  * Returns a hotkey character string for keydown and keyup events.


### PR DESCRIPTION
A `HotkeyString` is a valid `SequenceString` but with only one item in the sequence. So anything that accepts `SequenceString` should also accept `HotkeyString`.

This PR makes `HotkeyString` extend `SequenceString` to allow for this.

This felt a little backwards to me because sequences are built from hotkeys, not the other way around, but it is correct. I made a simple [demo](https://www.typescriptlang.org/play?#code/MYewdgzgLgBGICcC2BDANgSwF4FMAmAEiFANY4CeAQgimHjALwwDK5SARiGgBQDk8ydNnxFSFXgEoAUDgAeAB0Swo5eThgA5RKky5CxMuWZQEGMAHNGm7UL3McARwCuOMMBzHTFmADIYAbwBtAR1hfTEqGjoAXQAuGBMXAF8pKVBIWBDbfHtnV3dqWnomVg4uPizdHMcXNxxJGQUlBNV1LUEqvFza908zSyZoL0s-IMqw7vycQpj4xJwUtPBoGAALAworACIULZgUCGsOsNFDPosljJgIGqntlBh2PYOj0LtbuvPzVPSVqFX+hAACqrFBQACCwHc8igkzqEGY6ycaDwkOhUFOFEOTG4NzydXi7Te1XxvRM-QkjAAfAEUv9ASCwWicDC4e4EUiUcyYZjyBBcR93NJ6RZgaCIVCWbDBTgOSBkajJTyNnzuOsItJLn8AaLGRL0by5QqtPqpWzZVY1SrCTZOryvpSGDT-HSdeYxUylRiVUaUSbudLSbKrRqpAB6MMwAACUAgAFo5GpgFAEwgEIgpCL3XqA4bEfK-cQA+b+XiejgJEA) to test it out:

```ts
const normalizedHotkeyBrand = Symbol('normalizedHotkey')
export type NormalizedHotkeyString = NormalizedSequenceString & {[normalizedHotkeyBrand]: true}

const normalizedSequenceBrand = Symbol('normalizedSequence')
export type NormalizedSequenceString = string & {[normalizedSequenceBrand]: true}

const hotkey = "a" as NormalizedHotkeyString
const sequence = "a b" as NormalizedSequenceString

const thingsThatAcceptSequencesShouldAcceptHotkeys = (sequence: NormalizedSequenceString) => {}
thingsThatAcceptSequencesShouldAcceptHotkeys(sequence)
thingsThatAcceptSequencesShouldAcceptHotkeys(hotkey)

const thingsThatAcceptHotkeysShouldNotAcceptSequences = (hotkey: NormalizedHotkeyString) => {}
thingsThatAcceptHotkeysShouldNotAcceptSequences(hotkey)
// @ts-expect-error
thingsThatAcceptHotkeysShouldNotAcceptSequences(sequence)
```



> [!NOTE]
> Using string template types for this would solve this problem more elegantly, but that's a lot more complicated and comes with more of a compile-time performance cost. This is 'good enough'.