### PR TITLE
Fix default branch name in Pages publish workflow

### DIFF
--- a/.github/workflows/publish-pages.yml
+++ b/.github/workflows/publish-pages.yml
@@ -3,7 +3,7 @@ name: Publish Pages site
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build:


### PR DESCRIPTION
Changes the target branch for publishing Pages from `master` to `main`. I meant to fix this in https://github.com/github/hotkey/pull/96 but I guess I overlooked it.