### PR TITLE
Fix backtick mapping for macOS symbol layer

### DIFF
--- a/src/macos-symbol-layer.ts
+++ b/src/macos-symbol-layer.ts
@@ -16,7 +16,7 @@ export const macosSymbolLayerKeys: Record<string, string> = {
   ['º']: '0',
   ['–']: '-',
   ['≠']: '=',
-  ['`']: '~',
+  ['`']: '`',
   ['⁄']: '!',
   ['€']: '@',
   ['‹']: '#',


### PR DESCRIPTION
This was mapped to the tilde (~), which is Shift + ` (backtick) on US-English QWERTY layouts; Alt + ` is actually a Mac dead key for inputting accents, so we'll map the backtick to itself.