### PR TITLE
Don't use symbol plane unless `Alt` is pressed

### DIFF
--- a/src/hotkey.ts
+++ b/src/hotkey.ts
@@ -47,7 +47,7 @@ export function eventToHotkeyString(
   }
 
   if (!modifierKeyNames.includes(key)) {
-    const nonOptionPlaneKey = matchApplePlatform.test(platform) ? macosSymbolLayerKeys[key] ?? key : key
+    const nonOptionPlaneKey = hotkeyString.includes('Alt') && matchApplePlatform.test(platform) ? macosSymbolLayerKeys[key] ?? key : key
     const syntheticKey = syntheticKeyNames[nonOptionPlaneKey] ?? nonOptionPlaneKey
     hotkeyString.push(syntheticKey)
   }

--- a/src/hotkey.ts
+++ b/src/hotkey.ts
@@ -47,7 +47,8 @@ export function eventToHotkeyString(
   }
 
   if (!modifierKeyNames.includes(key)) {
-    const nonOptionPlaneKey = hotkeyString.includes('Alt') && matchApplePlatform.test(platform) ? macosSymbolLayerKeys[key] ?? key : key
+    const nonOptionPlaneKey =
+      hotkeyString.includes('Alt') && matchApplePlatform.test(platform) ? macosSymbolLayerKeys[key] ?? key : key
     const syntheticKey = syntheticKeyNames[nonOptionPlaneKey] ?? nonOptionPlaneKey
     hotkeyString.push(syntheticKey)
   }

--- a/src/macos-symbol-layer.ts
+++ b/src/macos-symbol-layer.ts
@@ -16,7 +16,6 @@ export const macosSymbolLayerKeys: Record<string, string> = {
   ['º']: '0',
   ['–']: '-',
   ['≠']: '=',
-  ['`']: '`',
   ['⁄']: '!',
   ['€']: '@',
   ['‹']: '#',


### PR DESCRIPTION
We can avoid future potential conflicts between regular keys and symbol plane keys by not checking the symbol plane map unless `Alt` is pressed. This is an easy safeguard that should make bugs like the one that https://github.com/github/hotkey/pull/113 fixed less likely to happen in the future.