### PR TITLE
Include `Shift` key with uppercase letter hotkeys

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -22,7 +22,7 @@
 	// "forwardPorts": [],
 
 	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "yarn install",
+	"postCreateCommand": "npm install",
 
 	// Comment out to connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
 	"remoteUser": "node",

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ for (const el of document.querySelectorAll('[data-shortcut]')) {
    3. Due to the inconsistent lowercasing of `event.key` on Mac and iOS when `Meta` is pressed along with `Shift`, it is recommended to avoid hotkey strings containing both `Mod` and `Shift`.
 7. `"Plus"` and `"Space"` are special key names to represent the `+` and ` ` keys respectively, because these symbols cannot be represented in the normal hotkey string syntax.
 8. You can use the comma key `,` as a hotkey, e.g. `a,,` would activate if the user typed `a` or `,`. `Control+,,x` would activate for `Control+,` or `x`.
+9. `"Shift"` should be included if it would be held, and the key name should match the 'uppercase' key name: `Shift+?`, `Shift+A`, `Shift+$`
 
 ### Example
 

--- a/src/hotkey.ts
+++ b/src/hotkey.ts
@@ -38,9 +38,9 @@ export function eventToHotkeyString(
   event: KeyboardEvent,
   platform: string = navigator.platform
 ): NormalizedHotkeyString {
-  const {ctrlKey, altKey, metaKey, key} = event
+  const {ctrlKey, altKey, metaKey, shiftKey, key} = event
   const hotkeyString: string[] = []
-  const modifiers: boolean[] = [ctrlKey, altKey, metaKey, showShift(event)]
+  const modifiers: boolean[] = [ctrlKey, altKey, metaKey, shiftKey]
 
   for (const [i, mod] of modifiers.entries()) {
     if (mod) hotkeyString.push(modifierKeyNames[i])
@@ -57,12 +57,6 @@ export function eventToHotkeyString(
 }
 
 const modifierKeyNames: string[] = ['Control', 'Alt', 'Meta', 'Shift']
-
-// We don't want to show `Shift` when `event.key` is capital
-function showShift(event: KeyboardEvent): boolean {
-  const {shiftKey, code, key} = event
-  return shiftKey && !(code.startsWith('Key') && key.toUpperCase() === key)
-}
 
 /**
  * Normalizes a hotkey string before comparing it to the serialized event

--- a/test/test.js
+++ b/test/test.js
@@ -98,13 +98,13 @@ describe('hotkey', function () {
     })
 
     it('triggers elements with capitalised key', function () {
-      setHTML('<button id="button1" data-hotkey="B">Button 1</button>')
+      setHTML('<button id="button1" data-hotkey="Shift+B">Button 1</button>')
       document.dispatchEvent(new KeyboardEvent('keydown', {shiftKey: true, code: 'KeyB', key: 'B'}))
       assert.include(elementsActivated, 'button1')
     })
 
     it('dispatches an event on the element once fired', function () {
-      setHTML('<button id="button1" data-hotkey="B">Button 1</button>')
+      setHTML('<button id="button1" data-hotkey="Shift+B">Button 1</button>')
       let fired = false
       document.querySelector('#button1').addEventListener('hotkey-fire', event => {
         fired = true
@@ -116,7 +116,7 @@ describe('hotkey', function () {
     })
 
     it('wont trigger action if the hotkey-fire event is cancelled', function () {
-      setHTML('<button id="button1" data-hotkey="B">Button 1</button>')
+      setHTML('<button id="button1" data-hotkey="Shift+B">Button 1</button>')
       document.querySelector('#button1').addEventListener('hotkey-fire', event => event.preventDefault())
       document.dispatchEvent(new KeyboardEvent('keydown', {shiftKey: true, code: 'KeyB', key: 'B'}))
       assert.notInclude(elementsActivated, 'button1')
@@ -286,7 +286,9 @@ describe('hotkey', function () {
       ['Alt+Shift+ArrowLeft', {altKey: true, shiftKey: true, key: 'ArrowLeft'}],
       ['Alt+Shift+ArrowLeft', {altKey: true, shiftKey: true, key: 'ArrowLeft'}, 'mac'],
       ['Control+Space', {ctrlKey: true, key: ' '}],
-      ['Shift+Plus', {shiftKey: true, key: '+'}]
+      ['Shift+Plus', {shiftKey: true, key: '+'}],
+      ['Shift+S', {shiftKey: true, key: 'S'}],
+      ['s', {shiftKey: true, key: 's'}]
     ]
     for (const [expected, keyEvent, platform = 'win / linux'] of tests) {
       it(`${JSON.stringify(keyEvent)} => ${expected}`, function (done) {


### PR DESCRIPTION
Currently we only include the `Shift` key in the hotkey string if the user is not typing a letter. This is inconsistent: for any other modifier, we always include it in the string if held. But for `Shift`, we only sometimes include it in the string if held.

To make hotkey strings easier to reason with, this PR changes the logic to always include `Shift` if held.

**This is a breaking change**: Any existing hotkeys that use uppercase letters without `Shift` will need to be updated to add `Shift`. So `A` would become `Shift+A`, `B` would become `Shift+B`, etc. This does mean that these hotkeys will no longer fire if the letter is pressed alone when `CapsLock` is on. I think this is acceptable because this behavior was never clearly defined in the docs and it is unintuitive that different effects might occur depending on whether caps lock is on or not.