### PR TITLE
Fix hotkey mapper tool

### DIFF
--- a/pages/hotkey_mapper.html
+++ b/pages/hotkey_mapper.html
@@ -12,21 +12,12 @@
 <body>
   <div class="mx-auto my-3 col-12 col-md-8 col-lg-6">
     <h1 id="app-name">Hotkey Code</h1>
-    <p id="hint">Press a key combination to see the corresponding hotkey string. Quickly press another combination to build a sequence.</p>
+    <p id="hint">Press a key combination to see the corresponding hotkey string. Quickly press another combination to
+      build a sequence.</p>
     <div class="position-relative">
-      <input
-        readonly
-        role="application"
-        aria-roledescription="Input Capture"
-        autofocus
-        aria-labelledby="app-name"
-        aria-describedby="hint sequence-hint"
-        aria-live="assertive"
-        aria-atomic="true"
-        id="hotkey-code"
-        class="border rounded-2 mt-2 p-6 f1 text-mono"
-        style="width: 100%"
-      />
+      <input readonly role="application" aria-roledescription="Input Capture" autofocus aria-labelledby="app-name"
+        aria-describedby="hint sequence-hint" aria-live="assertive" aria-atomic="true" id="hotkey-code"
+        class="border rounded-2 mt-2 p-6 f1 text-mono" style="width: 100%" />
 
       <div class="position-absolute bottom-2 left-3 right-3 d-flex" style="align-items: center; gap: 8px">
         <!-- This indicates that the input is listening for a sequence press. Ideally we'd have a way to tell screen
@@ -59,27 +50,42 @@
       }
     })
 
-    let currentsequence = null
+    const modifierKeyNames = ['Alt', 'Control', 'Meta', 'Shift'];
+
+    // we only want to add lone modifier keys to the sequence if they are lifted without pressing another key
+    // otherwise, the chord Control+f would become "Control Control+f". But we do want to be able to display sequences
+    // like "Control f", which is pressing and releasing control, then f.
+    let lastKeyDownModifierEvent = null
+
+    const registerEvent = (event) => {
+      lastKeyDownModifierEvent = null;
+
+      sequenceTracker.registerKeypress(event);
+      sequenceStatusElement.hidden = false;
+
+      event.target.value = sequenceTracker.path.join(SEQUENCE_DELIMITER);
+    }
 
     hotkeyCodeElement.addEventListener('keydown', event => {
-      if (event.key === "Tab") 
+      // always leave Tab alone so focus can leave the input
+      if (event.key === "Tab")
         return;
 
       event.preventDefault();
       event.stopPropagation();
 
-      currentsequence = eventToHotkeyString(event)
-      event.currentTarget.value = [...sequenceTracker.path, currentsequence].join(SEQUENCE_DELIMITER);
+      if (modifierKeyNames.includes(event.key)) {
+        lastKeyDownModifierEvent = event
+        return
+      }
+
+      registerEvent(event);
     })
 
     hotkeyCodeElement.addEventListener('keyup', () => {
-      // we don't just build the sequence from the keyup event because keyups don't necessarily map to keydowns - for
-      // example, the keyup event for meta+b is just meta.
-      if (currentsequence) {
-        sequenceTracker.registerKeypress(currentsequence)
-        sequenceStatusElement.hidden = false
-        currentsequence = null
-      }
+      // we still have to use the keydown event, not the keyup event, because the keyup event won't have the modifier
+      // properties (ie, `ctrlKey` will be false).
+      if (lastKeyDownModifierEvent) registerEvent(lastKeyDownModifierEvent);
     })
 
     resetButtonElement.addEventListener('click', () => {

--- a/pages/hotkey_mapper.html
+++ b/pages/hotkey_mapper.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
   <title>hotkey | Mapper Tool</title>
-  <link href="https://unpkg.com/@primer/css@^21.0.8/dist/primer.css" rel="stylesheet" />
+  <link crossorigin="anonymous" href="https://unpkg.com/@primer/css@^21.0.8/dist/primer.css" rel="stylesheet" />
   <script type="module" src="https://unpkg.com/@github/clipboard-copy-element@latest?module"></script>
 </head>
 

--- a/pages/hotkey_mapper.html
+++ b/pages/hotkey_mapper.html
@@ -58,8 +58,6 @@
     let lastKeyDownModifierEvent = null
 
     const registerEvent = (event) => {
-      lastKeyDownModifierEvent = null;
-
       sequenceTracker.registerKeypress(event);
       sequenceStatusElement.hidden = false;
 
@@ -67,6 +65,8 @@
     }
 
     hotkeyCodeElement.addEventListener('keydown', event => {
+      lastKeyDownModifierEvent = null;
+
       // always leave Tab alone so focus can leave the input
       if (event.key === "Tab")
         return;

--- a/pages/hotkey_mapper.html
+++ b/pages/hotkey_mapper.html
@@ -1,98 +1,105 @@
 <!doctype html>
 <html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width" />
+    <title>hotkey | Mapper Tool</title>
+    <link crossorigin="anonymous" href="https://unpkg.com/@primer/css@^21.0.8/dist/primer.css" rel="stylesheet" />
+    <script type="module" src="https://unpkg.com/@github/clipboard-copy-element@latest?module"></script>
+  </head>
 
-<head>
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width">
-  <title>hotkey | Mapper Tool</title>
-  <link crossorigin="anonymous" href="https://unpkg.com/@primer/css@^21.0.8/dist/primer.css" rel="stylesheet" />
-  <script type="module" src="https://unpkg.com/@github/clipboard-copy-element@latest?module"></script>
-</head>
+  <body>
+    <div class="mx-auto my-3 col-12 col-md-8 col-lg-6">
+      <h1 id="app-name">Hotkey Code</h1>
+      <p id="hint">
+        Press a key combination to see the corresponding hotkey string. Quickly press another combination to build a
+        sequence.
+      </p>
+      <div class="position-relative">
+        <input
+          readonly
+          role="application"
+          aria-roledescription="Input Capture"
+          autofocus
+          aria-labelledby="app-name"
+          aria-describedby="hint sequence-hint"
+          aria-live="assertive"
+          aria-atomic="true"
+          id="hotkey-code"
+          class="border rounded-2 mt-2 p-6 f1 text-mono"
+          style="width: 100%"
+        />
 
-<body>
-  <div class="mx-auto my-3 col-12 col-md-8 col-lg-6">
-    <h1 id="app-name">Hotkey Code</h1>
-    <p id="hint">Press a key combination to see the corresponding hotkey string. Quickly press another combination to
-      build a sequence.</p>
-    <div class="position-relative">
-      <input readonly role="application" aria-roledescription="Input Capture" autofocus aria-labelledby="app-name"
-        aria-describedby="hint sequence-hint" aria-live="assertive" aria-atomic="true" id="hotkey-code"
-        class="border rounded-2 mt-2 p-6 f1 text-mono" style="width: 100%" />
-
-      <div class="position-absolute bottom-2 left-3 right-3 d-flex" style="align-items: center; gap: 8px">
-        <!-- This indicates that the input is listening for a sequence press. Ideally we'd have a way to tell screen
+        <div class="position-absolute bottom-2 left-3 right-3 d-flex" style="align-items: center; gap: 8px">
+          <!-- This indicates that the input is listening for a sequence press. Ideally we'd have a way to tell screen
         readers this too, but if we make this live and add more text it will get annoying because it will conflict
         with the already-live input above. -->
-        <p id="sequence-status" class="color-fg-subtle" style="margin: 0" aria-hidden hidden>→</p>
+          <p id="sequence-status" class="color-fg-subtle" style="margin: 0" aria-hidden hidden>→</p>
 
-        <span style="flex: 1"></span>
+          <span style="flex: 1"></span>
 
-        <button id="reset-button" class="btn">Reset</button>
+          <button id="reset-button" class="btn">Reset</button>
 
-        <clipboard-copy for="hotkey-code" class="btn">
-          Copy to clipboard
-        </clipboard-copy>
+          <clipboard-copy for="hotkey-code" class="btn"> Copy to clipboard </clipboard-copy>
+        </div>
       </div>
     </div>
-  </div>
 
-  <script type="module">
-    import {eventToHotkeyString} from './hotkey/index.js'
-    import {SEQUENCE_DELIMITER, SequenceTracker} from './hotkey/sequence.js'
+    <script type="module">
+      import {eventToHotkeyString} from './hotkey/index.js'
+      import {SEQUENCE_DELIMITER, SequenceTracker} from './hotkey/sequence.js'
 
-    const hotkeyCodeElement = document.getElementById('hotkey-code')
-    const sequenceStatusElement = document.getElementById('sequence-status')
-    const resetButtonElement = document.getElementById('reset-button')
+      const hotkeyCodeElement = document.getElementById('hotkey-code')
+      const sequenceStatusElement = document.getElementById('sequence-status')
+      const resetButtonElement = document.getElementById('reset-button')
 
-    const sequenceTracker = new SequenceTracker({
-      onReset() {
-        sequenceStatusElement.hidden = true
-      }
-    })
+      const sequenceTracker = new SequenceTracker({
+        onReset() {
+          sequenceStatusElement.hidden = true
+        }
+      })
 
-    const modifierKeyNames = ['Alt', 'Control', 'Meta', 'Shift'];
+      const modifierKeyNames = ['Alt', 'Control', 'Meta', 'Shift']
 
-    // we only want to add lone modifier keys to the sequence if they are lifted without pressing another key
-    // otherwise, the chord Control+f would become "Control Control+f". But we do want to be able to display sequences
-    // like "Control f", which is pressing and releasing control, then f.
-    let lastKeyDownModifierEvent = null
+      // we only want to add lone modifier keys to the sequence if they are lifted without pressing another key
+      // otherwise, the chord Control+f would become "Control Control+f". But we do want to be able to display sequences
+      // like "Control f", which is pressing and releasing control, then f.
+      let lastKeyDownModifierEvent = null
 
-    const registerEvent = (event) => {
-      sequenceTracker.registerKeypress(event);
-      sequenceStatusElement.hidden = false;
+      const registerEvent = event => {
+        sequenceTracker.registerKeypress(event)
+        sequenceStatusElement.hidden = false
 
-      event.target.value = sequenceTracker.path.join(SEQUENCE_DELIMITER);
-    }
-
-    hotkeyCodeElement.addEventListener('keydown', event => {
-      lastKeyDownModifierEvent = null;
-
-      // always leave Tab alone so focus can leave the input
-      if (event.key === "Tab")
-        return;
-
-      event.preventDefault();
-      event.stopPropagation();
-
-      if (modifierKeyNames.includes(event.key)) {
-        lastKeyDownModifierEvent = event
-        return
+        event.target.value = sequenceTracker.path.join(SEQUENCE_DELIMITER)
       }
 
-      registerEvent(event);
-    })
+      hotkeyCodeElement.addEventListener('keydown', event => {
+        lastKeyDownModifierEvent = null
 
-    hotkeyCodeElement.addEventListener('keyup', () => {
-      // we still have to use the keydown event, not the keyup event, because the keyup event won't have the modifier
-      // properties (ie, `ctrlKey` will be false).
-      if (lastKeyDownModifierEvent) registerEvent(lastKeyDownModifierEvent);
-    })
+        // always leave Tab alone so focus can leave the input
+        if (event.key === 'Tab') return
 
-    resetButtonElement.addEventListener('click', () => {
-      sequenceTracker.reset()
-      hotkeyCodeElement.value = ''
-    })
-  </script>
-</body>
+        event.preventDefault()
+        event.stopPropagation()
 
+        if (modifierKeyNames.includes(event.key)) {
+          lastKeyDownModifierEvent = event
+          return
+        }
+
+        registerEvent(event)
+      })
+
+      hotkeyCodeElement.addEventListener('keyup', () => {
+        // we still have to use the keydown event, not the keyup event, because the keyup event won't have the modifier
+        // properties (ie, `ctrlKey` will be false).
+        if (lastKeyDownModifierEvent) registerEvent(lastKeyDownModifierEvent)
+      })
+
+      resetButtonElement.addEventListener('click', () => {
+        sequenceTracker.reset()
+        hotkeyCodeElement.value = ''
+      })
+    </script>
+  </body>
 </html>

--- a/pages/index.html
+++ b/pages/index.html
@@ -5,7 +5,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width">
   <title>hotkey</title>
-  <link href="https://unpkg.com/@primer/css@^16.0.0/dist/primer.css" rel="stylesheet" />
+  <link crossorigin="anonymous" href="https://unpkg.com/@primer/css@^16.0.0/dist/primer.css" rel="stylesheet" />
 </head>
 
 <body>


### PR DESCRIPTION
https://github.com/github/hotkey/pull/111 fixed the JS crashing in the hotkey mapper tool, but it's still not representing sequences properly. This PR fixes that.

The trickiness here comes from how we want to register sequences:

We want to register keydown events because they have the correct set of modifiers applied. For example, the `keydown` event for `Control+f` has `ctrlKey` set. But we can't register _all_ keydown events naively because we'd then register the sequence `Control Control+f`, which is wrong. But we also can't ignore all modifier keydown events, because we do want the user to be able to intentionally type `Control Control+f` if they release the `Control` key because pressing `Control+f`. So we store the keydown events for mod keys, then only register them if they are followed by a keyup with no more keydowns. 

This logic doesn't need to be updated in the hotkey library itself because it works differently there, only registering events based on what's configured in the hotkey string. On the other hand I definitely do need to fix this in the internal `ui-commands` platform 🙃

Also formats the file and fixes the style loading (was failing due to CORS)