### PR TITLE
Add user agent to mapper tool

### DIFF
--- a/pages/hotkey_mapper.html
+++ b/pages/hotkey_mapper.html
@@ -40,14 +40,23 @@
 
           <button id="reset-button" class="btn">Reset</button>
 
-          <clipboard-copy for="hotkey-code" class="btn"> Copy to clipboard </clipboard-copy>
+          <clipboard-copy for="hotkey-code" class="btn">Copy to clipboard</clipboard-copy>
         </div>
+      </div>
+
+      <div class="mt-2 color-fg-muted">
+        <span class="text-bold" id="user-agent-label">Your user agent:</span>
+
+        <code id="user-agent" aria-labelledby="user-agent-label" class="d-block">...</code>
       </div>
     </div>
 
     <script type="module">
       import {eventToHotkeyString} from './hotkey/index.js'
       import {SEQUENCE_DELIMITER, SequenceTracker} from './hotkey/sequence.js'
+
+      const userAgentElement = document.getElementById('user-agent')
+      userAgentElement.textContent = navigator.userAgent
 
       const hotkeyCodeElement = document.getElementById('hotkey-code')
       const sequenceStatusElement = document.getElementById('sequence-status')


### PR DESCRIPTION
Adds a "your user agent" section to the hotkey mapper tool. This will help us debug platforms if we ask someone to provide a screenshot of the result of some combination.

<img width="777" alt="Screenshot of the mapper tool. At the bottom is 'your user agent' in bold muted text, followed by the full user agent string in muted monospace text." src="https://github.com/github/hotkey/assets/2294248/1e7d1e3d-2837-4008-acb0-783453557b83">
