### PR TITLE
Use Node 16 for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
           registry-url: https://registry.npmjs.org/
           cache: npm
       - run: npm ci


### PR DESCRIPTION
The Publish/Release workflow [failed because it's still using Node 14](https://github.com/github/hotkey/actions/runs/7182982881/job/19560684597). This is an easy fix in the Actions config.