### PR TITLE
Don't call preventDefault() if the hotkey-fire event has been cancelled

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -52,8 +52,7 @@ function keyDownHandler(event: KeyboardEvent) {
     }
 
     if (elementToFire && shouldFire) {
-      fireDeterminedAction(elementToFire, sequenceTracker.path)
-      event.preventDefault()
+      if (fireDeterminedAction(elementToFire, sequenceTracker.path)) event.preventDefault()
     }
 
     sequenceTracker.reset()

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,15 +21,17 @@ export function isFormField(element: Node): boolean {
   )
 }
 
-export function fireDeterminedAction(el: HTMLElement, path: readonly NormalizedHotkeyString[]): void {
+export function fireDeterminedAction(el: HTMLElement, path: readonly NormalizedHotkeyString[]): boolean {
   const delegateEvent = new CustomEvent('hotkey-fire', {cancelable: true, detail: {path}})
   const cancelled = !el.dispatchEvent(delegateEvent)
-  if (cancelled) return
+  if (cancelled) return false
+  
   if (isFormField(el)) {
     el.focus()
   } else {
     el.click()
   }
+  return true
 }
 
 export function expandHotkeyToEdges(hotkey: string): NormalizedHotkeyString[][] {

--- a/test/test.js
+++ b/test/test.js
@@ -46,8 +46,10 @@ describe('hotkey', function () {
   describe('single key support', function () {
     it('triggers buttons that have a `data-hotkey` attribute', function () {
       setHTML('<button id="button1" data-hotkey="b">Button 1</button>')
-      document.dispatchEvent(new KeyboardEvent('keydown', {key: 'b'}))
+      const event = new KeyboardEvent('keydown', {cancelable: true, key: 'b'})
+      document.dispatchEvent(event)
       assert.include(elementsActivated, 'button1')
+      assert.ok(event.defaultPrevented, 'should call preventDefault on keydown event')
     })
 
     it('triggers buttons that get hotkey passed in as second argument', function () {
@@ -118,8 +120,10 @@ describe('hotkey', function () {
     it('wont trigger action if the hotkey-fire event is cancelled', function () {
       setHTML('<button id="button1" data-hotkey="Shift+B">Button 1</button>')
       document.querySelector('#button1').addEventListener('hotkey-fire', event => event.preventDefault())
-      document.dispatchEvent(new KeyboardEvent('keydown', {shiftKey: true, code: 'KeyB', key: 'B'}))
+      const event = new KeyboardEvent('keydown', {cancelable: true, shiftKey: true, code: 'KeyB', key: 'B'})
+      document.dispatchEvent(event)
       assert.notInclude(elementsActivated, 'button1')
+      assert.equal(event.defaultPrevented, false, 'should not prevent the keydown event when cancelled')
     })
 
     it('supports comma as a hotkey', function () {


### PR DESCRIPTION
We've ran into the issue that hotkeys are still triggered if the element is not clickable/accessible.
In our case the button is covered by the scrim of a dialog.

We use the hotkey-fire event to call preventDefault() on the hotkey event, but we want the original key event to still go through. This currently doesn't work as this library always calls preventDefault after firing the hotkey-fire event, even if the hotkey-fire event is cancelled.

This PR changes this behaviour to no longer prevent the key event if hotkey-fire event is cancelled.