### PR TITLE
Make localizeMod SSR safe

### DIFF
--- a/src/hotkey.ts
+++ b/src/hotkey.ts
@@ -90,9 +90,9 @@ const matchApplePlatform = /Mac|iPod|iPhone|iPad/i
 
 function localizeMod(hotkey: string, platform?: string | undefined): string {
   const ssrSafeWindow = typeof window === 'undefined' ? undefined : window
-  const safePlatform = ssrSafeWindow ? ssrSafeWindow.navigator.platform : platform
+  const safePlatform = platform ?? ssrSafeWindow?.navigator.platform ?? ""
 
-  const localModifier = matchApplePlatform.test(safePlatform ?? '') ? 'Meta' : 'Control'
+  const localModifier = matchApplePlatform.test(safePlatform) ? 'Meta' : 'Control'
   return hotkey.replace('Mod', localModifier)
 }
 

--- a/src/hotkey.ts
+++ b/src/hotkey.ts
@@ -90,7 +90,7 @@ const matchApplePlatform = /Mac|iPod|iPhone|iPad/i
 
 function localizeMod(hotkey: string, platform?: string | undefined): string {
   const ssrSafeWindow = typeof window === 'undefined' ? undefined : window
-  const safePlatform = platform ?? ssrSafeWindow?.navigator.platform ?? ""
+  const safePlatform = platform ?? ssrSafeWindow?.navigator.platform ?? ''
 
   const localModifier = matchApplePlatform.test(safePlatform) ? 'Meta' : 'Control'
   return hotkey.replace('Mod', localModifier)

--- a/src/hotkey.ts
+++ b/src/hotkey.ts
@@ -92,9 +92,9 @@ function localizeMod(hotkey: string, platform?: string | undefined): string {
   const ssrSafeWindow = typeof window === "undefined" ? undefined : window
   const safePlatform = ssrSafeWindow
     ? ssrSafeWindow.navigator.platform
-    : (platform ?? "")
+    : platform
 
-  const localModifier = matchApplePlatform.test(platform) ? 'Meta' : 'Control'
+  const localModifier = matchApplePlatform.test(platform ?? "") ? 'Meta' : 'Control'
   return hotkey.replace('Mod', localModifier)
 }
 

--- a/src/hotkey.ts
+++ b/src/hotkey.ts
@@ -88,7 +88,12 @@ export function normalizeHotkey(hotkey: string, platform?: string | undefined): 
 
 const matchApplePlatform = /Mac|iPod|iPhone|iPad/i
 
-function localizeMod(hotkey: string, platform: string = navigator.platform): string {
+function localizeMod(hotkey: string, platform?: string): string {
+  const ssrSafeWindow = typeof window === "undefined" ? undefined : window
+  const safePlatform = ssrSafeWindow
+    ? ssrSafeWindow.navigator.platform
+    : platform
+
   const localModifier = matchApplePlatform.test(platform) ? 'Meta' : 'Control'
   return hotkey.replace('Mod', localModifier)
 }

--- a/src/hotkey.ts
+++ b/src/hotkey.ts
@@ -88,7 +88,7 @@ export function normalizeHotkey(hotkey: string, platform?: string | undefined): 
 
 const matchApplePlatform = /Mac|iPod|iPhone|iPad/i
 
-function localizeMod(hotkey: string, platform: string): string {
+function localizeMod(hotkey: string, platform?: string | undefined): string {
   const ssrSafeWindow = typeof window === "undefined" ? undefined : window
   const safePlatform = ssrSafeWindow
     ? ssrSafeWindow.navigator.platform

--- a/src/hotkey.ts
+++ b/src/hotkey.ts
@@ -92,7 +92,7 @@ function localizeMod(hotkey: string, platform?: string | undefined): string {
   const ssrSafeWindow = typeof window === "undefined" ? undefined : window
   const safePlatform = ssrSafeWindow
     ? ssrSafeWindow.navigator.platform
-    : platform
+    : (platform ?? "")
 
   const localModifier = matchApplePlatform.test(platform) ? 'Meta' : 'Control'
   return hotkey.replace('Mod', localModifier)

--- a/src/hotkey.ts
+++ b/src/hotkey.ts
@@ -89,12 +89,10 @@ export function normalizeHotkey(hotkey: string, platform?: string | undefined): 
 const matchApplePlatform = /Mac|iPod|iPhone|iPad/i
 
 function localizeMod(hotkey: string, platform?: string | undefined): string {
-  const ssrSafeWindow = typeof window === "undefined" ? undefined : window
-  const safePlatform = ssrSafeWindow
-    ? ssrSafeWindow.navigator.platform
-    : platform
+  const ssrSafeWindow = typeof window === 'undefined' ? undefined : window
+  const safePlatform = ssrSafeWindow ? ssrSafeWindow.navigator.platform : platform
 
-  const localModifier = matchApplePlatform.test(platform ?? "") ? 'Meta' : 'Control'
+  const localModifier = matchApplePlatform.test(safePlatform ?? '') ? 'Meta' : 'Control'
   return hotkey.replace('Mod', localModifier)
 }
 

--- a/src/hotkey.ts
+++ b/src/hotkey.ts
@@ -76,7 +76,7 @@ const modifierKeyNames: string[] = ['Control', 'Alt', 'Meta', 'Shift']
  *   platforms.
  * - Ensures modifiers are sorted in a consistent order
  * @param hotkey a hotkey string
- * @param platform NOTE: this param is only intended to be used to mock `navigator.platform` in tests
+ * @param platform NOTE: this param is only intended to be used to mock `navigator.platform` in tests. `window.navigator.platform` is used by default.
  * @returns {string} normalized representation of the given hotkey string
  */
 export function normalizeHotkey(hotkey: string, platform?: string | undefined): NormalizedHotkeyString {
@@ -88,7 +88,7 @@ export function normalizeHotkey(hotkey: string, platform?: string | undefined): 
 
 const matchApplePlatform = /Mac|iPod|iPhone|iPad/i
 
-function localizeMod(hotkey: string, platform?: string): string {
+function localizeMod(hotkey: string, platform: string): string {
   const ssrSafeWindow = typeof window === "undefined" ? undefined : window
   const safePlatform = ssrSafeWindow
     ? ssrSafeWindow.navigator.platform

--- a/test/test-normalize-hotkey.js
+++ b/test/test-normalize-hotkey.js
@@ -26,7 +26,7 @@ describe('normalizeHotkey', () => {
     ['Mod+Alt+a', 'Control+Alt+a', 'win / linux'],
     ['Mod+Alt+a', 'Alt+Meta+a', 'mac'],
     // undefined platform doesn't localize and falls back to windows (SSR)
-    ["Mod+a", "Control+a", undefined],
+    ['Mod+a', 'Control+a', undefined],
     // Modifier sorting
     ['Shift+Alt+Meta+Control+m', 'Control+Alt+Meta+Shift+m'],
     ['Shift+Alt+Mod+m', 'Control+Alt+Shift+m', 'win']

--- a/test/test-normalize-hotkey.js
+++ b/test/test-normalize-hotkey.js
@@ -25,6 +25,8 @@ describe('normalizeHotkey', () => {
     ['Mod+)', 'Meta+)', 'mac'], // TODO: on a mac upper-case keys are lowercased when Meta is pressed
     ['Mod+Alt+a', 'Control+Alt+a', 'win / linux'],
     ['Mod+Alt+a', 'Alt+Meta+a', 'mac'],
+    // undefined platform doesn't localize and falls back to windows (SSR)
+    ["Mod+a", "Control+a", undefined],
     // Modifier sorting
     ['Shift+Alt+Meta+Control+m', 'Control+Alt+Meta+Shift+m'],
     ['Shift+Alt+Mod+m', 'Control+Alt+Shift+m', 'win']


### PR DESCRIPTION
When normalizing the hotkeys in an SSR environment, `localizeMod` breaks SSR with its direct `window.navigator` reference. 

This PR adds window checks to ensure safe SSR usage, updates types, and adds test coverage.