### PR TITLE
Run build before publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "test": "npm run lint && vitest run",
     "clean": "rm -rf dist",
     "prebuild": "npm run clean && mkdir dist",
-    "prepublishOnly": "npm run test",
+    "prepublishOnly": "npm run build",
     "buildSite": "npm run build && mkdir -p pages/hotkey && cp -r dist/* pages/hotkey"
   },
   "files": [


### PR DESCRIPTION
Currently we don't run `build` before publishing; we were relying on the `pretest` step before which is gone now (and wasn't a great approach). Now the published package is empty. 

We also don't need to run `test` before publishing since we do that in the workflow. So I changed the prepublish step to `build`.